### PR TITLE
fix: add Zod validation to authentication forms (#21)

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic"
 
 import { useState } from "react"
 import Link from "next/link"
@@ -18,17 +18,34 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
+import { forgotPasswordSchema } from "@/lib/schemas"
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")
   const [success, setSuccess] = useState(false)
+  const [emailError, setEmailError] = useState("")
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
     setError("")
+    setEmailError("")
+
+    const result = forgotPasswordSchema.safeParse({ email })
+
+    if (!result.success) {
+      result.error.issues.forEach(
+        (err: { path: (string | number | symbol)[]; message: string }) => {
+          if (err.path[0]) {
+            setEmailError(err.message)
+          }
+        }
+      )
+      setIsLoading(false)
+      return
+    }
 
     const { error } = await authClient.requestPasswordReset(
       { email },
@@ -94,9 +111,11 @@ export default function ForgotPasswordPage() {
                 placeholder="name@example.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {emailError && (
+                <p className="text-sm text-destructive">{emailError}</p>
+              )}
             </div>
           </CardContent>
           <CardFooter className="flex flex-col space-y-4">

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
+import { resetPasswordSchema } from "@/lib/schemas"
 
 export function ResetPasswordForm() {
   const router = useRouter()
@@ -26,21 +27,31 @@ export function ResetPasswordForm() {
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
-    setError("")
+    setErrors({})
 
-    if (password !== confirmPassword) {
-      setError("Passwords do not match")
+    const result = resetPasswordSchema.safeParse({ password, confirmPassword })
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {}
+      result.error.issues.forEach(
+        (err: { path: (string | number | symbol)[]; message: string }) => {
+          if (err.path[0]) {
+            fieldErrors[err.path[0] as string] = err.message
+          }
+        }
+      )
+      setErrors(fieldErrors)
       setIsLoading(false)
       return
     }
 
     if (!token) {
-      setError("Invalid reset token")
+      setErrors({ form: "Invalid reset token" })
       setIsLoading(false)
       return
     }
@@ -51,7 +62,7 @@ export function ResetPasswordForm() {
     })
 
     if (error) {
-      setError(error.message || "Failed to reset password")
+      setErrors({ form: error.message || "Failed to reset password" })
       setIsLoading(false)
     } else {
       router.push("/sign-in")
@@ -89,9 +100,9 @@ export function ResetPasswordForm() {
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
-            {error && (
+            {errors.form && (
               <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
+                {errors.form}
               </div>
             )}
             <div className="space-y-2">
@@ -102,9 +113,11 @@ export function ResetPasswordForm() {
                 placeholder="Create a new password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.password && (
+                <p className="text-sm text-destructive">{errors.password}</p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">Confirm New Password</Label>
@@ -114,9 +127,13 @@ export function ResetPasswordForm() {
                 placeholder="Confirm your new password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.confirmPassword && (
+                <p className="text-sm text-destructive">
+                  {errors.confirmPassword}
+                </p>
+              )}
             </div>
           </CardContent>
           <CardFooter className="flex flex-col space-y-4">

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic"
 
 import { useState } from "react"
 import Link from "next/link"
@@ -19,18 +19,35 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
+import { signInSchema } from "@/lib/schemas"
 
 export default function SignInPage() {
   const router = useRouter()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
-    setError("")
+    setErrors({})
+
+    const result = signInSchema.safeParse({ email, password })
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {}
+      result.error.issues.forEach(
+        (err: { path: (string | number | symbol)[]; message: string }) => {
+          if (err.path[0]) {
+            fieldErrors[err.path[0] as string] = err.message
+          }
+        }
+      )
+      setErrors(fieldErrors)
+      setIsLoading(false)
+      return
+    }
 
     const { error } = await authClient.signIn.email(
       { email, password },
@@ -42,7 +59,7 @@ export default function SignInPage() {
     )
 
     if (error) {
-      setError(error.message || "Failed to sign in")
+      setErrors({ form: error.message || "Failed to sign in" })
       setIsLoading(false)
     }
   }
@@ -64,9 +81,9 @@ export default function SignInPage() {
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
-            {error && (
+            {errors.form && (
               <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
+                {errors.form}
               </div>
             )}
             <div className="space-y-2">
@@ -77,9 +94,11 @@ export default function SignInPage() {
                 placeholder="name@example.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.email && (
+                <p className="text-sm text-destructive">{errors.email}</p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="password">Password</Label>
@@ -89,9 +108,11 @@ export default function SignInPage() {
                 placeholder="Enter your password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.password && (
+                <p className="text-sm text-destructive">{errors.password}</p>
+              )}
             </div>
             <div className="flex items-center justify-end">
               <Link

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-export const dynamic = 'force-dynamic'
+export const dynamic = "force-dynamic"
 
 import { useState } from "react"
 import Link from "next/link"
@@ -19,6 +19,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
+import { signUpSchema } from "@/lib/schemas"
 
 export default function SignUpPage() {
   const router = useRouter()
@@ -27,15 +28,30 @@ export default function SignUpPage() {
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
-    setError("")
+    setErrors({})
 
-    if (password !== confirmPassword) {
-      setError("Passwords do not match")
+    const result = signUpSchema.safeParse({
+      name,
+      email,
+      password,
+      confirmPassword,
+    })
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {}
+      result.error.issues.forEach(
+        (err: { path: (string | number | symbol)[]; message: string }) => {
+          if (err.path[0]) {
+            fieldErrors[err.path[0] as string] = err.message
+          }
+        }
+      )
+      setErrors(fieldErrors)
       setIsLoading(false)
       return
     }
@@ -50,7 +66,7 @@ export default function SignUpPage() {
     )
 
     if (error) {
-      setError(error.message || "Failed to sign up")
+      setErrors({ form: error.message || "Failed to sign up" })
       setIsLoading(false)
     }
   }
@@ -74,9 +90,9 @@ export default function SignUpPage() {
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
-            {error && (
+            {errors.form && (
               <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
+                {errors.form}
               </div>
             )}
             <div className="space-y-2">
@@ -87,9 +103,11 @@ export default function SignUpPage() {
                 placeholder="John Doe"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.name && (
+                <p className="text-sm text-destructive">{errors.name}</p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
@@ -99,9 +117,11 @@ export default function SignUpPage() {
                 placeholder="name@example.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.email && (
+                <p className="text-sm text-destructive">{errors.email}</p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="password">Password</Label>
@@ -111,9 +131,11 @@ export default function SignUpPage() {
                 placeholder="Create a password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.password && (
+                <p className="text-sm text-destructive">{errors.password}</p>
+              )}
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">Confirm Password</Label>
@@ -123,9 +145,13 @@ export default function SignUpPage() {
                 placeholder="Confirm your password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
-                required
                 disabled={isLoading}
               />
+              {errors.confirmPassword && (
+                <p className="text-sm text-destructive">
+                  {errors.confirmPassword}
+                </p>
+              )}
             </div>
           </CardContent>
           <CardFooter className="flex flex-col space-y-4">

--- a/app/(dashboard)/account/page.tsx
+++ b/app/(dashboard)/account/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { Loader2, Shield, KeyRound, Lock } from "lucide-react"
 
 import { authClient } from "@/lib/auth-client"
+import { changePasswordSchema } from "@/lib/schemas"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -72,8 +73,27 @@ export default function AccountPage() {
     setPasswordError("")
     setPasswordSuccess(false)
 
-    if (newPassword !== confirmPassword) {
-      setPasswordError("Passwords do not match")
+    const result = changePasswordSchema.safeParse({
+      currentPassword,
+      newPassword,
+      confirmPassword,
+    })
+
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {}
+      result.error.issues.forEach(
+        (err: { path: (string | number | symbol)[]; message: string }) => {
+          if (err.path[0]) {
+            fieldErrors[err.path[0] as string] = err.message
+          }
+        }
+      )
+      setPasswordError(
+        fieldErrors.confirmPassword ||
+          fieldErrors.newPassword ||
+          fieldErrors.currentPassword ||
+          "Validation failed"
+      )
       return
     }
 

--- a/lib/schemas/auth.ts
+++ b/lib/schemas/auth.ts
@@ -1,0 +1,76 @@
+import { z } from "zod"
+
+export const signInSchema = z.object({
+  email: z.string().min(1, "Email is required").email("Invalid email address"),
+  password: z.string().min(1, "Password is required"),
+})
+
+export type SignInInput = z.infer<typeof signInSchema>
+
+export const signUpSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Name is required")
+      .min(2, "Name must be at least 2 characters")
+      .max(100, "Name must be less than 100 characters"),
+    email: z
+      .string()
+      .min(1, "Email is required")
+      .email("Invalid email address"),
+    password: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters")
+      .max(128, "Password must be less than 128 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  })
+
+export type SignUpInput = z.infer<typeof signUpSchema>
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().min(1, "Email is required").email("Invalid email address"),
+})
+
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>
+
+export const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters")
+      .max(128, "Password must be less than 128 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  })
+
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required"),
+    newPassword: z
+      .string()
+      .min(1, "New password is required")
+      .min(8, "Password must be at least 8 characters")
+      .max(128, "Password must be less than 128 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  })
+  .refine((data) => data.currentPassword !== data.newPassword, {
+    message: "New password must be different from current password",
+    path: ["newPassword"],
+  })
+
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -1,0 +1,15 @@
+export {
+  signInSchema,
+  signUpSchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  changePasswordSchema,
+} from "./auth"
+
+export type {
+  SignInInput,
+  SignUpInput,
+  ForgotPasswordInput,
+  ResetPasswordInput,
+  ChangePasswordInput,
+} from "./auth"

--- a/tasks/2026-03-10-phase-1-create-first-tests.md
+++ b/tasks/2026-03-10-phase-1-create-first-tests.md
@@ -1,0 +1,124 @@
+<!-- Task template for feature/bug slices. Copy to tasks/YYYY-MM-DD-phase-N-desc.md -->
+
+# BEFORE TACKLING THIS TASK: Analyze available MCPs and Skills
+
+Available MCPs (use for research):
+| MCP | Use When | Key Tools |
+|-----|----------|-----------|
+| nextjs_docs | Any Next.js question | fetch docs by path |
+| nextjs_index | Discover running dev servers | list servers, get tools |
+| shadcn | UI components | search, get examples, add |
+| postgres | Database work | execute_sql, analyze |
+| github | Issues, PRs | create_issue, search |
+| better-auth | Auth questions | search docs, ask |
+| context7 | Any library docs | resolve, query |
+| magicui | UI animations | getComponents, getBackgrounds |
+| filesystem | File operations | read, write, glob |
+| playwright | Browser automation | navigate, click, fill |
+
+Available Skills (invoke when relevant):
+| Skill | Trigger |
+|-------|---------|
+| better-auth-best-practices | auth, better-auth |
+| create-auth-skill | new auth, add auth |
+| email-and-password-best-practices | email/password flows |
+| organization-best-practices | orgs, teams, rbac |
+| two-factor-authentication-best-practices | 2FA, MFA, TOTP |
+| find-skills | "how do I", "find a skill", unsure |
+
+IMPORTANT: Before starting this task:
+
+1. Analyze what the task involves
+2. Check which MCPs could help with research
+3. Use find-skills skill if unsure whether a skill exists for this task domain
+4. # Document which MCPs/Skills you'll use in Implementation Notes
+   -->
+
+# Title: 2026-03-10 — Phase 1 — Create First Tests
+
+- Status: PENDING
+- Phase: 1
+- Branch: test/phase-1-first-tests
+- Owner: @
+- Created: 2026-03-10
+- Completion:
+
+## Objective
+
+Create the first set of critical tests for the SaaS application focusing on authentication flows and security.
+
+## Scope (SCOPE LOCK)
+
+WHAT I WILL DO:
+
+1. Check Context7 MCP for Vitest docs to understand testing best practices
+2. Create Vitest tests for environment validation (`lib/Env.ts`)
+3. Create Vitest tests for database health check (`lib/db-health.ts`)
+4. Create Playwright E2E tests for Auth flows:
+   - Sign up form validation and submission
+   - Sign in with valid/invalid credentials
+   - Sign out flow
+   - Password reset (forgot password → reset)
+   - Protected routes redirect when unauthenticated
+5. Create Playwright E2E tests for Security:
+   - Dashboard route protection (unauthenticated blocked)
+   - Admin route protection (non-admin blocked)
+   - Session validation
+
+WHAT I WILL NOT DO:
+
+- OAuth provider tests
+- 2FA tests
+- Passkey tests
+- Email verification tests
+- Admin user management tests
+- Stripe/billing tests
+
+## Plan (ordered steps)
+
+1. Use context7_resolve_library_id to get Vitest library ID
+2. Use context7_query_docs to fetch Vitest testing best practices
+3. Create `__tests__/lib/env.test.ts` for env validation
+4. Create `__tests__/lib/db-health.test.ts` for DB health
+5. Create `__tests__/e2e/sign-up.test.ts` for sign up flow
+6. Create `__tests__/e2e/sign-in.test.ts` for sign in flow
+7. Create `__tests__/e2e/sign-out.test.ts` for sign out flow
+8. Create `__tests__/e2e/password-reset.test.ts` for password reset
+9. Create `__tests__/e2e/protected-routes.test.ts` for protected routes
+10. Create `__tests__/e2e/admin-protection.test.ts` for admin protection
+11. Verify tests run correctly
+
+## Implementation Notes
+
+**MCPs/Skills to use for this task:**
+
+- context7_resolve_library_id - Get Vitest library ID
+- context7_query_docs - Fetch Vitest docs for testing patterns
+- filesystem - Read existing code to understand structure
+
+## Verification
+
+- `bun run test:vitest` passes
+- `bun run test:playwright` runs all E2E tests
+- `bun run lint` passes
+- `bun run check:types` passes
+
+## Issues Created
+
+-
+
+## Rapport (to fill at completion)
+
+- What Was Done:
+- What Was Learned:
+- What Was Left Out:
+- Issues Created:
+
+## Completion
+
+- Status: COMPLETED
+- Completed At: YYYY-MM-DDTHH:MM:SSZ
+
+## Notes
+
+- Add links to PRs, CI runs, or external references here.


### PR DESCRIPTION
## Summary

- Added Zod schemas in `lib/schemas/auth.ts` for all auth forms
- Implemented client-side validation for:
  - Sign up (name 2-100 chars, email, password 8-128 chars)
  - Sign in (email, password)
  - Forgot password (email)
  - Reset password (password 8-128 chars)
  - Change password (current password, new password validation)

## Changes

- Created `lib/schemas/auth.ts` with Zod schemas
- Created `lib/schemas/index.ts` for exports
- Updated all auth form pages to use Zod validation

Closes #21