### PR TITLE
fix: use bunx for lefthook in postinstall for Vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
     "check:types": "tsc --noEmit",
-    "postinstall": "lefthook install",
+    "postinstall": "bunx lefthook install",
     "lefthook": "lefthook",
     "commitmsg": "commitlint --edit",
     "db:clear": "bun run scripts/clear-db.ts",


### PR DESCRIPTION
## Summary

- Change `postinstall` script from `lefthook install` to `bunx lefthook install`
- Fixes Vercel deployment failure where `lefthook` binary is not in PATH during `bun install`
