### PR TITLE
feat: add impersonation banner, set role UI, and session revocation

### DIFF
--- a/app/(admin)/admin/layout.tsx
+++ b/app/(admin)/admin/layout.tsx
@@ -6,6 +6,7 @@ import { authClient } from "@/lib/auth-client"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
+import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export default function AdminLayout({
   children,
@@ -72,6 +73,7 @@ export default function AdminLayout({
     >
       <AppSidebar variant="inset" user={sidebarUser} />
       <SidebarInset>
+        <ImpersonationBanner />
         <SiteHeader />
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">

--- a/app/(admin)/admin/users/page.tsx
+++ b/app/(admin)/admin/users/page.tsx
@@ -38,7 +38,26 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { MoreHorizontal, Ban, UserX, LogIn, Loader2 } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  MoreHorizontal,
+  Ban,
+  UserX,
+  LogIn,
+  Loader2,
+  Shield,
+  Monitor,
+  Smartphone,
+  Globe,
+  X,
+  RotateCcw,
+} from "lucide-react"
 
 type UserWithRole = {
   id: string
@@ -51,11 +70,35 @@ type UserWithRole = {
   role: string | null | undefined
 }
 
+type SessionInfo = {
+  id: string
+  token: string
+  userAgent?: string | null
+  ipAddress?: string | null
+  createdAt: Date
+  expiresAt: Date
+}
+
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<UserWithRole[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState("")
   const [actionLoading, setActionLoading] = useState<string | null>(null)
+
+  // Set role state
+  const [roleDialogUser, setRoleDialogUser] = useState<UserWithRole | null>(
+    null
+  )
+  const [selectedRole, setSelectedRole] = useState<string>("")
+  const [isSettingRole, setIsSettingRole] = useState(false)
+
+  // Session state
+  const [sessionsDialogUser, setSessionsDialogUser] =
+    useState<UserWithRole | null>(null)
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false)
+  const [revokingToken, setRevokingToken] = useState<string | null>(null)
+  const [isRevokingAll, setIsRevokingAll] = useState(false)
 
   const { data: currentSession } = authClient.useSession()
 
@@ -129,6 +172,91 @@ export default function AdminUsersPage() {
     }
   }
 
+  async function handleSetRole() {
+    if (!roleDialogUser || !selectedRole) return
+    setIsSettingRole(true)
+    try {
+      await authClient.admin.setRole({
+        userId: roleDialogUser.id,
+        role: selectedRole as "user" | "admin",
+      })
+      await loadUsers()
+      setRoleDialogUser(null)
+    } catch (error) {
+      console.error("Failed to set role:", error)
+    } finally {
+      setIsSettingRole(false)
+    }
+  }
+
+  async function loadSessions(userId: string) {
+    setIsLoadingSessions(true)
+    try {
+      const { data } = await authClient.admin.listUserSessions({
+        userId,
+      })
+      setSessions((data?.sessions as SessionInfo[]) || [])
+    } catch (error) {
+      console.error("Failed to load sessions:", error)
+      setSessions([])
+    } finally {
+      setIsLoadingSessions(false)
+    }
+  }
+
+  function handleOpenSessionsDialog(user: UserWithRole) {
+    setSessionsDialogUser(user)
+    loadSessions(user.id)
+  }
+
+  async function handleRevokeSession(sessionToken: string) {
+    setRevokingToken(sessionToken)
+    try {
+      await authClient.admin.revokeUserSession({
+        sessionToken,
+      })
+      if (sessionsDialogUser) {
+        await loadSessions(sessionsDialogUser.id)
+      }
+    } catch (error) {
+      console.error("Failed to revoke session:", error)
+    } finally {
+      setRevokingToken(null)
+    }
+  }
+
+  async function handleRevokeAllSessions() {
+    if (!sessionsDialogUser) return
+    setIsRevokingAll(true)
+    try {
+      await authClient.admin.revokeUserSessions({
+        userId: sessionsDialogUser.id,
+      })
+      setSessions([])
+    } catch (error) {
+      console.error("Failed to revoke all sessions:", error)
+    } finally {
+      setIsRevokingAll(false)
+    }
+  }
+
+  function parseUserAgent(ua?: string | null) {
+    if (!ua) return { label: "Unknown device", icon: Monitor }
+    const lower = ua.toLowerCase()
+    if (
+      lower.includes("mobile") ||
+      lower.includes("android") ||
+      lower.includes("iphone")
+    ) {
+      return { label: "Mobile", icon: Smartphone }
+    }
+    if (lower.includes("chrome")) return { label: "Chrome", icon: Globe }
+    if (lower.includes("firefox")) return { label: "Firefox", icon: Globe }
+    if (lower.includes("safari")) return { label: "Safari", icon: Globe }
+    if (lower.includes("edge")) return { label: "Edge", icon: Globe }
+    return { label: "Browser", icon: Monitor }
+  }
+
   const getInitials = (name: string | null) => {
     if (!name) return "U"
     return name
@@ -168,6 +296,7 @@ export default function AdminUsersPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>User</TableHead>
+                  <TableHead>Role</TableHead>
                   <TableHead>Email Verified</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Created</TableHead>
@@ -178,7 +307,7 @@ export default function AdminUsersPage() {
                 {users.length === 0 ? (
                   <TableRow>
                     <TableCell
-                      colSpan={5}
+                      colSpan={6}
                       className="text-center text-muted-foreground"
                     >
                       No users found
@@ -207,6 +336,16 @@ export default function AdminUsersPage() {
                             </p>
                           </div>
                         </div>
+                      </TableCell>
+                      <TableCell>
+                        {user.role === "admin" ? (
+                          <Badge className="bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+                            <Shield className="mr-1 h-3 w-3" />
+                            Admin
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline">User</Badge>
+                        )}
                       </TableCell>
                       <TableCell>
                         {user.emailVerified ? (
@@ -241,6 +380,21 @@ export default function AdminUsersPage() {
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setSelectedRole(user.role || "user")
+                                setRoleDialogUser(user)
+                              }}
+                            >
+                              <Shield className="mr-2 h-4 w-4" />
+                              Change Role
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => handleOpenSessionsDialog(user)}
+                            >
+                              <Monitor className="mr-2 h-4 w-4" />
+                              Sessions
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() => handleImpersonate(user.id)}
                               disabled={user.id === currentSession?.user?.id}
@@ -299,6 +453,155 @@ export default function AdminUsersPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Set Role Dialog */}
+      <AlertDialog
+        open={!!roleDialogUser}
+        onOpenChange={(open) => {
+          if (!open) setRoleDialogUser(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Change Role</AlertDialogTitle>
+            <AlertDialogDescription>
+              Change the role for <strong>{roleDialogUser?.email}</strong>. This
+              will affect their access permissions immediately.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="py-4">
+            <Select value={selectedRole} onValueChange={setSelectedRole}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">User</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSettingRole}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                handleSetRole()
+              }}
+              disabled={isSettingRole || !selectedRole}
+            >
+              {isSettingRole ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Save Role
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Sessions Dialog */}
+      <AlertDialog
+        open={!!sessionsDialogUser}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSessionsDialogUser(null)
+            setSessions([])
+          }
+        }}
+      >
+        <AlertDialogContent className="max-w-lg">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Sessions for{" "}
+              {sessionsDialogUser?.name || sessionsDialogUser?.email}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              View and manage active sessions. Revoking a session will sign the
+              user out of that device.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="max-h-[50vh] overflow-y-auto">
+            {isLoadingSessions ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin" />
+              </div>
+            ) : sessions.length === 0 ? (
+              <p className="py-4 text-center text-sm text-muted-foreground">
+                No active sessions
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {sessions.map((session) => {
+                  const { label, icon: Icon } = parseUserAgent(
+                    session.userAgent
+                  )
+                  const isCurrentSession =
+                    session.token === currentSession?.session?.token
+                  return (
+                    <div
+                      key={session.id}
+                      className="flex items-center justify-between rounded-lg border p-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Icon className="h-5 w-5 text-muted-foreground" />
+                        <div>
+                          <p className="text-sm font-medium">
+                            {label}
+                            {isCurrentSession && (
+                              <Badge
+                                variant="secondary"
+                                className="ml-2 text-xs"
+                              >
+                                Current
+                              </Badge>
+                            )}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {session.ipAddress || "Unknown IP"} &middot;{" "}
+                            {new Date(session.createdAt).toLocaleString()}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleRevokeSession(session.token)}
+                        disabled={
+                          revokingToken === session.token || isCurrentSession
+                        }
+                      >
+                        {revokingToken === session.token ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <X className="h-3 w-3" />
+                        )}
+                      </Button>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Close</AlertDialogCancel>
+            {sessions.length > 0 && (
+              <Button
+                variant="destructive"
+                onClick={handleRevokeAllSessions}
+                disabled={isRevokingAll}
+              >
+                {isRevokingAll ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                )}
+                Revoke All
+              </Button>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -6,6 +6,7 @@ import { authClient } from "@/lib/auth-client"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
+import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export default function DashboardLayout({
   children,
@@ -50,6 +51,7 @@ export default function DashboardLayout({
     >
       <AppSidebar variant="inset" user={sidebarUser} />
       <SidebarInset>
+        <ImpersonationBanner />
         <SiteHeader />
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { authClient } from "@/lib/auth-client"
+import { Button } from "@/components/ui/button"
+import { AlertTriangle, LogOut, Loader2 } from "lucide-react"
+
+export function ImpersonationBanner() {
+  const router = useRouter()
+  const [isStopping, setIsStopping] = useState(false)
+  const { data: session } = authClient.useSession()
+
+  const impersonatedBy = (session?.session as Record<string, unknown>)
+    ?.impersonatedBy as string | undefined
+
+  if (!impersonatedBy) return null
+
+  async function handleStop() {
+    setIsStopping(true)
+    try {
+      await authClient.admin.stopImpersonating()
+      router.push("/admin")
+    } catch (error) {
+      console.error("Failed to stop impersonating:", error)
+      setIsStopping(false)
+    }
+  }
+
+  return (
+    <div className="sticky top-0 z-[60] flex items-center justify-center gap-4 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 dark:bg-amber-600 dark:text-amber-50">
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      <span>
+        You are impersonating{" "}
+        <strong>{session?.user?.name || session?.user?.email}</strong>
+      </span>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={handleStop}
+        disabled={isStopping}
+        className="h-7 border-amber-900/20 bg-amber-950/10 text-amber-950 hover:bg-amber-950/20 dark:border-amber-50/20 dark:bg-amber-50/10 dark:text-amber-50 dark:hover:bg-amber-50/20"
+      >
+        {isStopping ? (
+          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+        ) : (
+          <LogOut className="mr-1 h-3 w-3" />
+        )}
+        Stop Impersonating
+      </Button>
+    </div>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { ThemeToggle } from "@/components/ui/theme-toggle"
+import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export function Navbar() {
   const { data: session, isPending } = authClient.useSession()
@@ -42,79 +43,85 @@ export function Navbar() {
       .slice(0, 2) || "U"
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container mx-auto flex h-14 items-center justify-between px-4">
-        <Link href="/" className="flex items-center gap-2 font-semibold">
-          <Home className="h-4 w-4" />
-          <span>Home</span>
-        </Link>
+    <>
+      <ImpersonationBanner />
+      <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container mx-auto flex h-14 items-center justify-between px-4">
+          <Link href="/" className="flex items-center gap-2 font-semibold">
+            <Home className="h-4 w-4" />
+            <span>Home</span>
+          </Link>
 
-        <div className="flex items-center gap-2">
-          <ThemeToggle />
-          {isPending ? (
-            <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
-          ) : user ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="relative h-8 w-8 rounded-full"
-                >
-                  <Avatar className="h-8 w-8">
-                    <AvatarImage src={user.image || ""} alt={user.name || ""} />
-                    <AvatarFallback>{initials}</AvatarFallback>
-                  </Avatar>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-56" align="end" forceMount>
-                <DropdownMenuLabel className="font-normal">
-                  <div className="flex flex-col space-y-1">
-                    <p className="text-sm leading-none font-medium">
-                      {user.name}
-                    </p>
-                    <p className="text-xs leading-none text-muted-foreground">
-                      {user.email}
-                    </p>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuItem onClick={() => router.push("/dashboard")}>
-                    <LayoutDashboard className="mr-2 h-4 w-4" />
-                    Dashboard
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => router.push("/account")}>
-                    <User className="mr-2 h-4 w-4" />
-                    Account
-                  </DropdownMenuItem>
-                  {user.role === "admin" && (
-                    <DropdownMenuItem onClick={() => router.push("/admin")}>
-                      <Shield className="mr-2 h-4 w-4" />
-                      Admin
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            {isPending ? (
+              <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+            ) : user ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="relative h-8 w-8 rounded-full"
+                  >
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage
+                        src={user.image || ""}
+                        alt={user.name || ""}
+                      />
+                      <AvatarFallback>{initials}</AvatarFallback>
+                    </Avatar>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-56" align="end" forceMount>
+                  <DropdownMenuLabel className="font-normal">
+                    <div className="flex flex-col space-y-1">
+                      <p className="text-sm leading-none font-medium">
+                        {user.name}
+                      </p>
+                      <p className="text-xs leading-none text-muted-foreground">
+                        {user.email}
+                      </p>
+                    </div>
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem onClick={() => router.push("/dashboard")}>
+                      <LayoutDashboard className="mr-2 h-4 w-4" />
+                      Dashboard
                     </DropdownMenuItem>
-                  )}
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleSignOut}>
-                  <LogOut className="mr-2 h-4 w-4" />
-                  Sign out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Link href="/sign-in">
-                <Button variant="ghost" size="sm">
-                  Sign in
-                </Button>
-              </Link>
-              <Link href="/sign-up">
-                <Button size="sm">Sign up</Button>
-              </Link>
-            </div>
-          )}
+                    <DropdownMenuItem onClick={() => router.push("/account")}>
+                      <User className="mr-2 h-4 w-4" />
+                      Account
+                    </DropdownMenuItem>
+                    {user.role === "admin" && (
+                      <DropdownMenuItem onClick={() => router.push("/admin")}>
+                        <Shield className="mr-2 h-4 w-4" />
+                        Admin
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleSignOut}>
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Sign out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Link href="/sign-in">
+                  <Button variant="ghost" size="sm">
+                    Sign in
+                  </Button>
+                </Link>
+                <Link href="/sign-up">
+                  <Button size="sm">Sign up</Button>
+                </Link>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- **Impersonation banner**: Amber sticky banner shown on all pages when an admin is impersonating a user, with a "Stop Impersonating" button
- **Set role UI**: "Change Role" dropdown item in admin users table opens a dialog with user/admin select. Self-demotion is disabled.
- **Session revocation**: "Sessions" dropdown item opens a dialog listing active sessions with per-session revoke and "Revoke All" button
- **Role badge column**: Purple "Admin" badge or outline "User" badge in the users table