### PR TITLE
chore: remove Storybook from Vitest test runner

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,6 @@
 import { defineConfig } from "vitest/config"
 import path from "path"
-import { fileURLToPath } from "node:url"
-import { storybookTest } from "@storybook/addon-vitest/vitest-plugin"
-import { playwright } from "@vitest/browser-playwright"
-const dirname =
-  typeof __dirname !== "undefined"
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url))
 
-// More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   resolve: {
     alias: {
@@ -16,43 +8,13 @@ export default defineConfig({
     },
   },
   test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    exclude: ["node_modules", ".next", "dist"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],
     },
-    projects: [
-      {
-        extends: true,
-        test: {
-          globals: true,
-          environment: "node",
-          include: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
-          exclude: ["node_modules", ".next", "dist"],
-        },
-      },
-      {
-        extends: true,
-        plugins: [
-          // The plugin will run tests for the stories defined in your Storybook config
-          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-          storybookTest({
-            configDir: path.join(dirname, ".storybook"),
-          }),
-        ],
-        test: {
-          name: "storybook",
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: playwright({}),
-            instances: [
-              {
-                browser: "chromium",
-              },
-            ],
-          },
-        },
-      },
-    ],
   },
 })

--- a/vitest.shims.d.ts
+++ b/vitest.shims.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@vitest/browser-playwright" />


### PR DESCRIPTION
## Summary

- Simplify `vitest.config.ts` from multi-project to single node project
- Remove `@storybook/addon-vitest` and `@vitest/browser-playwright` browser testing from the test runner
- Delete `vitest.shims.d.ts` (was for browser-playwright provider)
- Storybook itself stays unchanged (dev server, stories, addons)
- Test suite now runs in **260ms** vs ~5s with browser tests

Related: #43, #44