### PR TITLE
refactor(auth): convert layouts and pages to server components

### DIFF
--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -40,6 +40,7 @@ type(scope): short description
 ### Rules
 
 - **type** and **scope** are lowercase
+- try to make the commit message not long if possible
 - **scope** is optional but recommended — use the affected module/area (e.g., `auth`, `api`, `ui`)
 - **short description** is imperative mood, no period at the end (e.g., "add login endpoint" not "added login endpoint")
 - Keep the whole line under ~72 characters

--- a/GIT-WORKFLOW.md
+++ b/GIT-WORKFLOW.md
@@ -1,0 +1,18 @@
+flowchart TD
+A[Start Feature()] --> B[Create Branch: feat/auth-login]
+
+    B --> C[Write Code]
+    C --> D[Commit: feat(auth): add login endpoint] // try to make the commit not long if possible
+
+    D --> E[Push Branch]
+    E --> F[Open PR #42]
+
+    F --> G[Review Process]
+
+    G -->|Fix Needed| H[fix(auth): handle edge case]
+    H --> E
+
+    G -->|Approved| I[Merge PR]
+
+    I --> J[feat(auth): add login endpoint (#42)]
+    J --> K[Deploy / Main Updated]

--- a/app/[locale]/(admin)/admin/layout.tsx
+++ b/app/[locale]/(admin)/admin/layout.tsx
@@ -1,61 +1,19 @@
-"use client"
-
-import { useEffect, useState } from "react"
-import { useTranslations } from "next-intl"
-import { useParams, useRouter } from "next/navigation"
-import { authClient } from "@/lib/auth-client"
+import { requireSession } from "@/lib/auth-session"
+import { redirect } from "next/navigation"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const t = useTranslations()
-  const router = useRouter()
-  const { locale } = useParams<{ locale: string }>()
-  const [isAdmin, setIsAdmin] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
-  const { data: session, isPending } = authClient.useSession()
+  const session = await requireSession()
 
-  useEffect(() => {
-    async function checkAdmin() {
-      if (isPending) return
-      if (!session) {
-        router.push(`/${locale}/sign-in`)
-        return
-      }
-
-      const { data: hasPermission } = await authClient.admin.hasPermission({
-        permissions: {
-          user: ["list"],
-        },
-      })
-
-      if (!hasPermission?.success) {
-        router.push(`/${locale}/dashboard`)
-        return
-      }
-
-      setIsAdmin(true)
-      setIsLoading(false)
-    }
-
-    checkAdmin()
-  }, [isPending, session, router, locale])
-
-  if (isLoading || !session || !isAdmin) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="mt-4 text-muted-foreground">{t("common.loading")}</p>
-        </div>
-      </div>
-    )
+  if (session.user.role !== "admin") {
+    redirect("/dashboard")
   }
 
   const user = session.user
@@ -76,7 +34,7 @@ export default function AdminLayout({
     >
       <AppSidebar variant="inset" user={sidebarUser} />
       <SidebarInset>
-        <ImpersonationBanner />
+        <ImpersonationBanner session={session} />
         <SiteHeader />
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">

--- a/app/[locale]/(admin)/admin/page.tsx
+++ b/app/[locale]/(admin)/admin/page.tsx
@@ -1,56 +1,36 @@
-"use client"
-
-import { useEffect, useState } from "react"
-import { authClient } from "@/lib/auth-client"
-import { clientLogger } from "@/lib/client-logger"
+import { auth } from "@/lib/auth"
+import { headers } from "next/headers"
+import { logger } from "@/lib/logger"
 import { SectionCards } from "./_components/section-cards"
 import { ChartAreaInteractive } from "./_components/chart-area-interactive"
 import { DataTable, type UserRow } from "./_components/data-table"
 
-export default function AdminDashboardPage() {
-  const [users, setUsers] = useState<UserRow[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+export default async function AdminDashboardPage() {
+  let users: UserRow[] = []
 
-  useEffect(() => {
-    async function loadUsers() {
-      try {
-        const { data: usersResponse } = await authClient.admin.listUsers({
-          query: {},
-        })
+  try {
+    const usersResponse = await auth.api.listUsers({
+      query: {},
+      headers: await headers(),
+    })
 
-        const rawUsers = usersResponse?.users || []
-        const mappedUsers: UserRow[] = rawUsers.map((u) => ({
-          id: u.id,
-          name: u.name || "",
-          email: u.email,
-          emailVerified: u.emailVerified,
-          banned: Boolean(u.banned),
-          role: u.role || "user",
-          createdAt:
-            u.createdAt instanceof Date
-              ? u.createdAt.toISOString()
-              : String(u.createdAt),
-        }))
-
-        setUsers(mappedUsers)
-      } catch (error) {
-        clientLogger.error("Failed to load admin users", {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    loadUsers()
-  }, [])
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-      </div>
-    )
+    const rawUsers = usersResponse?.users || []
+    users = rawUsers.map((u) => ({
+      id: u.id,
+      name: u.name || "",
+      email: u.email,
+      emailVerified: u.emailVerified,
+      banned: Boolean(u.banned),
+      role: u.role || "user",
+      createdAt:
+        u.createdAt instanceof Date
+          ? u.createdAt.toISOString()
+          : String(u.createdAt),
+    }))
+  } catch (error) {
+    logger.error("Failed to load admin users", {
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
 
   return (

--- a/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -1,9 +1,6 @@
-"use client"
-
-import { useTranslations } from "next-intl"
-import { useParams } from "next/navigation"
+import { getTranslations, getLocale } from "next-intl/server"
 import Link from "next/link"
-import { authClient } from "@/lib/auth-client"
+import { getSession } from "@/lib/auth-session"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -16,10 +13,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { User, Shield, Settings } from "lucide-react"
 
-export default function DashboardPage() {
-  const t = useTranslations()
-  const { locale } = useParams<{ locale: string }>()
-  const { data: session } = authClient.useSession()
+export default async function DashboardPage() {
+  const t = await getTranslations()
+  const locale = await getLocale()
+  const session = await getSession()
 
   const user = session?.user
   if (!user) return null

--- a/app/[locale]/(dashboard)/layout.tsx
+++ b/app/[locale]/(dashboard)/layout.tsx
@@ -1,40 +1,15 @@
-"use client"
-
-import { useEffect } from "react"
-import { useTranslations } from "next-intl"
-import { useParams, useRouter } from "next/navigation"
-import { authClient } from "@/lib/auth-client"
+import { requireSession } from "@/lib/auth-session"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const t = useTranslations()
-  const router = useRouter()
-  const { locale } = useParams<{ locale: string }>()
-  const { data: session, isPending } = authClient.useSession()
-
-  useEffect(() => {
-    if (!isPending && !session) {
-      router.push(`/${locale}/sign-in`)
-    }
-  }, [isPending, session, router, locale])
-
-  if (isPending || !session) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="mt-4 text-muted-foreground">{t("common.loading")}</p>
-        </div>
-      </div>
-    )
-  }
+  const session = await requireSession()
 
   const user = session.user
   const sidebarUser = {
@@ -54,7 +29,7 @@ export default function DashboardLayout({
     >
       <AppSidebar variant="inset" user={sidebarUser} />
       <SidebarInset>
-        <ImpersonationBanner />
+        <ImpersonationBanner session={session} />
         <SiteHeader />
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,8 +1,5 @@
-"use client"
-
-import { useTranslations } from "next-intl"
+import { getTranslations, getLocale } from "next-intl/server"
 import Link from "next/link"
-import { useParams } from "next/navigation"
 import {
   ShieldCheck,
   ShieldAlert,
@@ -11,21 +8,21 @@ import {
   ArrowRight,
 } from "lucide-react"
 
-import { authClient } from "@/lib/auth-client"
+import { getSession } from "@/lib/auth-session"
 import { Navbar } from "@/components/navbar"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-export default function Page() {
-  const t = useTranslations()
-  const { locale } = useParams<{ locale: string }>()
-  const { data: session, isPending } = authClient.useSession()
+export default async function Page() {
+  const t = await getTranslations()
+  const locale = await getLocale()
+  const session = await getSession()
   const user = session?.user
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <Navbar />
+      <Navbar session={session} />
 
       <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-16 md:px-6">
         <header className="space-y-2">
@@ -37,15 +34,7 @@ export default function Page() {
           </p>
         </header>
 
-        {isPending ? (
-          <Card>
-            <CardContent className="py-8">
-              <p className="text-sm text-muted-foreground">
-                {t("common.loading")}
-              </p>
-            </CardContent>
-          </Card>
-        ) : !user ? (
+        {!user ? (
           <Card>
             <CardHeader>
               <CardTitle>{t("landing.notSignedIn")}</CardTitle>

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -5,15 +5,15 @@ import { useTranslations } from "next-intl"
 import { useParams, useRouter } from "next/navigation"
 import { authClient } from "@/lib/auth-client"
 import { clientLogger } from "@/lib/client-logger"
+import type { Session } from "@/lib/auth"
 import { Button } from "@/components/ui/button"
 import { AlertTriangle, LogOut, Loader2 } from "lucide-react"
 
-export function ImpersonationBanner() {
+export function ImpersonationBanner({ session }: { session: Session | null }) {
   const t = useTranslations()
   const router = useRouter()
   const { locale } = useParams<{ locale: string }>()
   const [isStopping, setIsStopping] = useState(false)
-  const { data: session } = authClient.useSession()
 
   const impersonatedBy = (session?.session as Record<string, unknown>)
     ?.impersonatedBy as string | undefined

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react"
 
 import { authClient } from "@/lib/auth-client"
+import type { Session } from "@/lib/auth"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,11 +29,10 @@ import {
 import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
 
-export function Navbar() {
+export function Navbar({ session }: { session: Session | null }) {
   const t = useTranslations()
   const { locale } = useParams<{ locale: string }>()
   const pathname = usePathname()
-  const { data: session, isPending } = authClient.useSession()
   const user = session?.user
   const router = useRouter()
 
@@ -56,7 +56,7 @@ export function Navbar() {
 
   return (
     <>
-      <ImpersonationBanner />
+      <ImpersonationBanner session={session} />
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container mx-auto flex h-14 items-center justify-between px-4">
           <Link
@@ -96,9 +96,7 @@ export function Navbar() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            {isPending ? (
-              <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
-            ) : user ? (
+            {user ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture
+
+## Passing Data: Props (Not Context)
+
+This project passes session data from server layouts to client components using **props**, not React Context or state management libraries like Zustand.
+
+### Why Props?
+
+**React docs on Context:**
+
+> "Context is primarily used when some data needs to be accessible by **many components at different nesting levels**. Apply it sparingly because it makes component reuse more difficult."
+
+**Our component tree:**
+
+```
+DashboardLayout (server)
+└── AppSidebar (client) ← needs user data
+    └── NavUser (client) ← needs user data
+```
+
+This is **not** prop drilling - it's passing data where it's needed (2-3 levels max).
+
+### When Context _Would_ Make Sense
+
+- 5+ levels of components that don't use the data
+- Multiple unrelated branches needing the same data
+- Global state updated from many places
+
+Our session doesn't fit any of these - it flows in a clear hierarchy.
+
+### Pattern
+
+```tsx
+// Server layout fetches session
+export default async function Layout() {
+  const session = await requireSession()
+  return <AppSidebar user={session.user} />
+}
+
+// Client component receives as prop
+;("use client")
+export function AppSidebar({ user }) {
+  return <NavUser user={user} />
+}
+```
+
+### No Session Provider, No Zustand, No Abstractions
+
+Just props. Simple, clear, and recommended by the React team.


### PR DESCRIPTION
## Summary

- Convert dashboard and admin layouts to server components
- Convert landing page and dashboard page to server components
- Admin dashboard now fetches users server-side
- Navbar and ImpersonationBanner accept session as props
- Zero JS for session checking, no loading flicker
- Server-enforced auth (can't be bypassed)

## Benefits

| Before | After |
|---|---|
| Client-side session check | Server-side session check |
| Loading spinner on every page | No loading state |
| `authClient.useSession()` everywhere | `await getSession()` in layouts |
| 3 states to handle (loading, error, success) | Straightforward async |

## Files Changed

- `app/[locale]/(dashboard)/layout.tsx` - Server component with `requireSession()`
- `app/[locale]/(admin)/admin/layout.tsx` - Server component with role check
- `app/[locale]/page.tsx` - Server component
- `app/[locale]/(dashboard)/dashboard/page.tsx` - Server component
- `app/[locale]/(admin)/admin/page.tsx` - Server-side data fetching
- `components/navbar.tsx` - Accepts session prop
- `components/impersonation-banner.tsx` - Accepts session prop
- `docs/ARCHITECTURE.md` - Documents props vs context decision