### PR TITLE
fix(i18n): complete next-intl setup to follow official best practices

### DIFF
--- a/app/[locale]/(admin)/admin/layout.tsx
+++ b/app/[locale]/(admin)/admin/layout.tsx
@@ -1,5 +1,6 @@
 import { requireSession } from "@/lib/auth-session"
-import { redirect } from "next/navigation"
+import { setRequestLocale } from "next-intl/server"
+import { redirect } from "@/lib/navigation"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
@@ -7,13 +8,17 @@ import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export default async function AdminLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: Promise<{ locale: string }>
 }) {
+  const { locale } = await params
+  setRequestLocale(locale)
   const session = await requireSession()
 
   if (session.user.role !== "admin") {
-    redirect("/dashboard")
+    redirect({ href: "/dashboard", locale })
   }
 
   const user = session.user

--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -20,11 +20,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
-import { forgotPasswordSchema } from "@/lib/schemas"
+import { useForgotPasswordSchema } from "@/lib/schemas"
 
 export default function ForgotPasswordPage() {
   const t = useTranslations()
   const { locale } = useParams<{ locale: string }>()
+  const forgotPasswordSchema = useForgotPasswordSchema()
   const [email, setEmail] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")

--- a/app/[locale]/(auth)/reset-password/reset-password-form.tsx
+++ b/app/[locale]/(auth)/reset-password/reset-password-form.tsx
@@ -19,11 +19,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
-import { resetPasswordSchema } from "@/lib/schemas"
+import { useResetPasswordSchema } from "@/lib/schemas"
 
 export function ResetPasswordForm() {
   const t = useTranslations()
   const router = useRouter()
+  const resetPasswordSchema = useResetPasswordSchema()
   const { locale } = useParams<{ locale: string }>()
   const searchParams = useSearchParams()
   const token = searchParams.get("token")

--- a/app/[locale]/(auth)/sign-in/page.tsx
+++ b/app/[locale]/(auth)/sign-in/page.tsx
@@ -21,11 +21,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
-import { signInSchema } from "@/lib/schemas"
+import { useSignInSchema } from "@/lib/schemas"
 
 export default function SignInPage() {
   const t = useTranslations()
   const router = useRouter()
+  const signInSchema = useSignInSchema()
   const { locale } = useParams<{ locale: string }>()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")

--- a/app/[locale]/(auth)/sign-up/page.tsx
+++ b/app/[locale]/(auth)/sign-up/page.tsx
@@ -21,11 +21,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
-import { signUpSchema } from "@/lib/schemas"
+import { useSignUpSchema } from "@/lib/schemas"
 
 export default function SignUpPage() {
   const t = useTranslations()
   const router = useRouter()
+  const signUpSchema = useSignUpSchema()
   const { locale } = useParams<{ locale: string }>()
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")

--- a/app/[locale]/(dashboard)/layout.tsx
+++ b/app/[locale]/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { requireSession } from "@/lib/auth-session"
+import { setRequestLocale } from "next-intl/server"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "./_components/site-header"
@@ -6,9 +7,13 @@ import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export default async function DashboardLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: Promise<{ locale: string }>
 }) {
+  const { locale } = await params
+  setRequestLocale(locale)
   const session = await requireSession()
 
   const user = session.user

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,9 +1,28 @@
+import { hasLocale } from "next-intl"
 import { NextIntlClientProvider } from "next-intl"
 import { getMessages } from "next-intl/server"
 import { setRequestLocale } from "next-intl/server"
+import { notFound } from "next/navigation"
+import { Geist, Geist_Mono } from "next/font/google"
 
+import { routing } from "@/lib/routing"
+import { cn } from "@/lib/utils"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
+
+const fontSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-sans",
+})
+
+const fontMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+})
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }))
+}
 
 export default async function LocaleLayout({
   children,
@@ -13,14 +32,32 @@ export default async function LocaleLayout({
   params: Promise<{ locale: string }>
 }>) {
   const { locale } = await params
+
+  if (!hasLocale(routing.locales, locale)) {
+    notFound()
+  }
+
   setRequestLocale(locale)
   const messages = await getMessages()
 
   return (
-    <NextIntlClientProvider messages={messages}>
-      <ThemeProvider>
-        <TooltipProvider>{children}</TooltipProvider>
-      </ThemeProvider>
-    </NextIntlClientProvider>
+    <html
+      lang={locale}
+      suppressHydrationWarning
+      className={cn(
+        "antialiased",
+        fontMono.variable,
+        "font-sans",
+        fontSans.variable
+      )}
+    >
+      <body>
+        <NextIntlClientProvider messages={messages}>
+          <ThemeProvider>
+            <TooltipProvider>{children}</TooltipProvider>
+          </ThemeProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
   )
 }

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,0 +1,23 @@
+import { useTranslations } from "next-intl"
+import Link from "next/link"
+
+export default function NotFound() {
+  const t = useTranslations()
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-muted-foreground">404</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          {t("common.notFound")}
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-block text-sm text-primary hover:underline"
+        >
+          {t("common.home")}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,35 +1,10 @@
-import { Geist, Geist_Mono } from "next/font/google"
-
 import "./globals.css"
-import { cn } from "@/lib/utils"
 import "@/lib/logger"
-
-const fontSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-sans",
-})
-
-const fontMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-mono",
-})
 
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return (
-    <html
-      suppressHydrationWarning
-      className={cn(
-        "antialiased",
-        fontMono.variable,
-        "font-sans",
-        fontSans.variable
-      )}
-    >
-      <body>{children}</body>
-    </html>
-  )
+  return children
 }

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,15 +1,12 @@
+import { hasLocale } from "next-intl"
 import { getRequestConfig } from "next-intl/server"
 import { routing } from "./routing"
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  let locale = await requestLocale
-
-  if (
-    !locale ||
-    !routing.locales.includes(locale as (typeof routing.locales)[number])
-  ) {
-    locale = routing.defaultLocale
-  }
+  const requested = await requestLocale
+  const locale = hasLocale(routing.locales, requested)
+    ? requested
+    : routing.defaultLocale
 
   return {
     locale,

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,5 @@
+import { createNavigation } from "next-intl/navigation"
+import { routing } from "./routing"
+
+export const { Link, redirect, usePathname, useRouter } =
+  createNavigation(routing)

--- a/lib/schemas/auth.ts
+++ b/lib/schemas/auth.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { useTranslations } from "next-intl"
 
-// Static schemas (for backward compatibility - uses default English messages)
+// Static schemas (for server-side validation and type inference)
 export const signInSchema = z.object({
   email: z.email("Invalid email address"),
   password: z.string().min(1, "Password is required"),
@@ -74,7 +74,66 @@ export const changePasswordSchema = z
 
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>
 
-// Translatable schema hooks (use these for i18n support)
+// Translatable schema hooks — use these in client components for i18n support
+export function useSignInSchema() {
+  const t = useTranslations("validation")
+
+  return z.object({
+    email: z.email(t("invalidEmail")),
+    password: z.string().min(1, t("passwordRequired")),
+  })
+}
+
+export function useSignUpSchema() {
+  const t = useTranslations("validation")
+
+  return z
+    .object({
+      name: z
+        .string()
+        .min(1, t("nameRequired"))
+        .min(2, t("nameMinLength"))
+        .max(100, t("nameMaxLength")),
+      email: z.email(t("invalidEmail")),
+      password: z
+        .string()
+        .min(1, t("passwordRequired"))
+        .min(8, t("passwordMinLength"))
+        .max(128, t("passwordMaxLength")),
+      confirmPassword: z.string().min(1, t("confirmPasswordRequired")),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t("passwordsDoNotMatch"),
+      path: ["confirmPassword"],
+    })
+}
+
+export function useForgotPasswordSchema() {
+  const t = useTranslations("validation")
+
+  return z.object({
+    email: z.email(t("invalidEmail")),
+  })
+}
+
+export function useResetPasswordSchema() {
+  const t = useTranslations("validation")
+
+  return z
+    .object({
+      password: z
+        .string()
+        .min(1, t("passwordRequired"))
+        .min(8, t("passwordMinLength"))
+        .max(128, t("passwordMaxLength")),
+      confirmPassword: z.string().min(1, t("confirmPasswordRequired")),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+      message: t("passwordsDoNotMatch"),
+      path: ["confirmPassword"],
+    })
+}
+
 export function useChangePasswordSchema() {
   const t = useTranslations("validation")
 

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -4,6 +4,10 @@ export {
   forgotPasswordSchema,
   resetPasswordSchema,
   changePasswordSchema,
+  useSignInSchema,
+  useSignUpSchema,
+  useForgotPasswordSchema,
+  useResetPasswordSchema,
   useChangePasswordSchema,
 } from "./auth"
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,7 +21,8 @@
     "email": "Email",
     "password": "Password",
     "name": "Name",
-    "orContinueWith": "Or continue with"
+    "orContinueWith": "Or continue with",
+    "notFound": "Page not found"
   },
   "navbar": {
     "dashboard": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -21,7 +21,8 @@
     "email": "E-mail",
     "password": "Mot de passe",
     "name": "Nom",
-    "orContinueWith": "Ou continuer avec"
+    "orContinueWith": "Ou continuer avec",
+    "notFound": "Page non trouvée"
   },
   "navbar": {
     "dashboard": "Tableau de bord",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,106 +1,46 @@
+import createMiddleware from "next-intl/middleware"
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { getSessionCookie } from "better-auth/cookies"
-import { logger } from "@/lib/logger"
+import { routing } from "./lib/routing"
 
-const locales = ["en", "fr"] as const
-const defaultLocale = "en"
+const handleI18nRouting = createMiddleware(routing)
 
-function getLocale(request: NextRequest): string {
-  const acceptLanguage = request.headers.get("accept-language") ?? ""
-  const languages = acceptLanguage
-    .split(",")
-    .map((lang) => lang.split(";")[0].trim().toLowerCase())
-
-  for (const lang of languages) {
-    if (lang === "fr" || lang.startsWith("fr-")) return "fr"
-    if (lang === "en" || lang.startsWith("en-")) return "en"
-  }
-
-  return defaultLocale
-}
-
-function hasLocaleInPath(pathname: string): boolean {
-  return locales.some(
-    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`
-  )
-}
-
-function extractLocaleAndPath(pathname: string): {
-  locale: string
-  pathWithoutLocale: string
-} {
-  for (const locale of locales) {
-    if (pathname === `/${locale}`) {
-      return { locale, pathWithoutLocale: "/" }
-    }
-    if (pathname.startsWith(`/${locale}/`)) {
-      return { locale, pathWithoutLocale: pathname.slice(locale.length + 1) }
-    }
-  }
-  return { locale: defaultLocale, pathWithoutLocale: pathname }
-}
-
-export function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // Skip API routes and static files
-  if (pathname.startsWith("/api/")) {
-    return NextResponse.next()
-  }
-
-  // If no locale in path, redirect to add locale
-  if (!hasLocaleInPath(pathname)) {
-    const locale = getLocale(request)
-    request.nextUrl.pathname = `/${locale}${pathname}`
-    logger.debug("Redirecting to locale-prefixed path", {
-      from: pathname,
-      to: request.nextUrl.pathname,
-      locale,
-    })
-    return NextResponse.redirect(request.nextUrl)
-  }
-
-  // Extract locale and path for auth checks
-  const { pathWithoutLocale } = extractLocaleAndPath(pathname)
+  // Auth routes — redirect authenticated users to dashboard
   const sessionCookie = getSessionCookie(request)
-
   const authRoutes = ["/sign-in", "/sign-up"]
-  const isAuthRoute = authRoutes.includes(pathWithoutLocale)
 
-  if (isAuthRoute && sessionCookie) {
-    const locale = pathname.split("/")[1]
-    logger.debug(
-      "Authenticated user accessing auth route, redirecting to dashboard",
-      {
-        path: pathname,
-        locale,
-      }
-    )
-    return NextResponse.redirect(new URL(`/${locale}/dashboard`, request.url))
+  if (authRoutes.some((route) => pathname.endsWith(route)) && sessionCookie) {
+    return NextResponse.redirect(new URL("/dashboard", request.url))
   }
 
-  // Protected routes (everything except auth routes, landing page, and public pages)
-  const publicRoutes = [
-    "/",
-    "/forgot-password",
-    "/reset-password",
-    "/verification-sent",
-    "/verify-email",
-    "/2fa",
-  ]
-  const isPublicRoute = publicRoutes.includes(pathWithoutLocale)
+  // Let next-intl handle locale routing
+  const response = handleI18nRouting(request)
 
-  if (!isPublicRoute && !isAuthRoute && !sessionCookie) {
-    const locale = pathname.split("/")[1]
-    logger.warning("Unauthenticated user accessing protected route", {
-      path: pathname,
-      locale,
-    })
-    return NextResponse.redirect(new URL(`/${locale}/sign-in`, request.url))
+  // Protected routes — redirect unauthenticated users to sign-in
+  if (response.status === 200 && !sessionCookie) {
+    const publicRoutes = [
+      "/",
+      "/sign-in",
+      "/sign-up",
+      "/forgot-password",
+      "/reset-password",
+      "/verification-sent",
+      "/verify-email",
+      "/2fa",
+    ]
+
+    const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(\/|$)/, "/")
+
+    if (!publicRoutes.includes(pathWithoutLocale)) {
+      return NextResponse.redirect(new URL("/sign-in", request.url))
+    }
   }
 
-  return NextResponse.next()
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Complete the next-intl implementation to follow official documentation patterns. Based on the audit in `i18n_analysis.md`.

## Changes

### Critical
- **`proxy.ts`**: Replaced 110-line hand-rolled middleware with `createMiddleware(routing)` composed with auth checks (~35 lines). Now handles locale persistence via cookies, proper Accept-Language negotiation, and alternate links for SEO.
- **`app/layout.tsx`**: Simplified to minimal passthrough (fonts/styles moved to locale layout).
- **`app/[locale]/layout.tsx`**: Now renders `<html lang={locale}>` for accessibility/SEO. Added `generateStaticParams` for static rendering. Added `hasLocale` + `notFound()` for invalid locale handling. Takes over fonts/styles from root layout.
- **`lib/navigation.ts`**: Created with `createNavigation(routing)` (needed for locale-aware `redirect` in admin layout).

### High
- **`app/[locale]/(dashboard)/layout.tsx`**: Added `setRequestLocale(locale)` for static rendering support.
- **`app/[locale]/(admin)/admin/layout.tsx`**: Added `setRequestLocale(locale)`. Fixed locale-unaware `redirect("/dashboard")` → `redirect({ href: "/dashboard", locale })`.

### Medium
- **`lib/schemas/auth.ts`**: Added 4 translatable schema hooks (`useSignInSchema`, `useSignUpSchema`, `useForgotPasswordSchema`, `useResetPasswordSchema`) following the existing `useChangePasswordSchema` pattern.
- **`lib/schemas/index.ts`**: Updated barrel export with new hooks.
- **4 auth pages**: Updated to use translatable schema hooks instead of static English schemas.
- **`app/[locale]/not-found.tsx`**: Added locale-aware 404 page.
- **`lib/i18n.ts`**: Replaced custom locale validation with official `hasLocale` utility.
- **`messages/en.json` + `messages/fr.json`**: Added `common.notFound` translation key.

Closes #61