### PR TITLE
fix(i18n): correct next-intl implementation issues

### DIFF
--- a/app/[locale]/(admin)/admin/_components/app-sidebar.tsx
+++ b/app/[locale]/(admin)/admin/_components/app-sidebar.tsx
@@ -36,68 +36,69 @@ export function AppSidebar({
 }: React.ComponentProps<typeof Sidebar> & {
   user: { name: string; email: string; avatar: string }
 }) {
-  const t = useTranslations()
+  const tAdmin = useTranslations("admin")
+  const tSidebar = useTranslations("sidebar")
 
   const data = {
     navMain: [
       {
-        title: t("admin.dashboard"),
+        title: tAdmin("dashboard"),
         url: `/admin`,
         icon: LayoutDashboard,
       },
       {
-        title: t("admin.users"),
+        title: tAdmin("users"),
         url: `/admin/users`,
         icon: Users,
       },
       {
-        title: t("admin.billing"),
+        title: tAdmin("billing"),
         url: `/admin/billing`,
         icon: CreditCard,
       },
       {
-        title: t("admin.analytics"),
+        title: tAdmin("analytics"),
         url: `/admin/analytics`,
         icon: BarChart3,
       },
     ],
     navOperations: [
       {
-        title: t("admin.systemHealth"),
+        title: tAdmin("systemHealth"),
         url: `/admin/system`,
         icon: Activity,
       },
       {
-        title: t("admin.support"),
+        title: tAdmin("support"),
         url: `/admin/support`,
         icon: LifeBuoy,
       },
     ],
     navManagement: [
       {
-        title: t("admin.auditLog"),
+        title: tAdmin("auditLog"),
         url: `/admin/audit`,
         icon: ScrollText,
       },
       {
-        title: t("admin.featureFlags"),
+        title: tAdmin("featureFlags"),
         url: `/admin/features`,
         icon: Flag,
       },
     ],
     navSecondary: [
       {
-        title: t("sidebar.home"),
+        title: tSidebar("home"),
         url: `/`,
         icon: Home,
       },
       {
-        title: t("admin.settings"),
+        title: tAdmin("settings"),
         url: `/admin/settings`,
         icon: Settings,
       },
       {
-        title: t("admin.getHelp"),
+        title: tAdmin("getHelp"),
         url: `/admin/help`,
         icon: HelpCircle,
       },
@@ -116,7 +117,7 @@ export function AppSidebar({
               <Link href="/admin">
                 <Shield className="size-5!" />
                 <span className="text-base font-semibold">
-                  {t("admin.adminPanel")}
+                  {tAdmin("adminPanel")}
                 </span>
               </Link>
             </SidebarMenuButton>
@@ -126,11 +127,11 @@ export function AppSidebar({
       <SidebarContent>
         <NavMain items={data.navMain} />
         <SidebarGroup>
-          <SidebarGroupLabel>{t("admin.operations")}</SidebarGroupLabel>
+          <SidebarGroupLabel>{tAdmin("operations")}</SidebarGroupLabel>
           <NavMain items={data.navOperations} />
         </SidebarGroup>
         <SidebarGroup>
-          <SidebarGroupLabel>{t("admin.management")}</SidebarGroupLabel>
+          <SidebarGroupLabel>{tAdmin("management")}</SidebarGroupLabel>
           <NavMain items={data.navManagement} />
         </SidebarGroup>
         <NavSecondary items={data.navSecondary} className="mt-auto" />

--- a/app/[locale]/(admin)/admin/layout.tsx
+++ b/app/[locale]/(admin)/admin/layout.tsx
@@ -1,24 +1,11 @@
 import { Locale } from "next-intl"
-import { setRequestLocale } from "next-intl/server"
+import { setRequestLocale, getTranslations } from "next-intl/server"
 import { requireSession } from "@/lib/auth-session"
 import { redirect } from "@/lib/navigation"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "@/components/sidebar"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
-
-const routeLabels: Record<string, string> = {
-  admin: "Admin",
-  users: "Users",
-  billing: "Billing",
-  analytics: "Analytics",
-  system: "System Health",
-  support: "Support",
-  audit: "Audit Log",
-  features: "Feature Flags",
-  settings: "Settings",
-  help: "Help",
-}
 
 export default async function AdminLayout({
   children,
@@ -29,6 +16,20 @@ export default async function AdminLayout({
 }) {
   const { locale } = await params
   setRequestLocale(locale as Locale)
+
+  const t = await getTranslations("routeLabels")
+  const routeLabels: Record<string, string> = {
+    admin: t("admin"),
+    users: t("users"),
+    billing: t("billing"),
+    analytics: t("analytics"),
+    system: t("system"),
+    support: t("support"),
+    audit: t("audit"),
+    features: t("features"),
+    settings: t("settings"),
+    help: t("help"),
+  }
 
   const session = await requireSession()
 

--- a/app/[locale]/(admin)/admin/page.tsx
+++ b/app/[locale]/(admin)/admin/page.tsx
@@ -1,3 +1,5 @@
+import { Locale } from "next-intl"
+import { setRequestLocale } from "next-intl/server"
 import { auth } from "@/lib/auth"
 import { headers } from "next/headers"
 import { logger } from "@/lib/logger"
@@ -7,10 +9,17 @@ import { SectionCards } from "./_components/section-cards"
 import { ChartAreaInteractive } from "./_components/chart-area-interactive"
 import { DataTable, type UserRow } from "./_components/data-table"
 
-export default async function AdminDashboardPage() {
+export default async function AdminDashboardPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale as Locale)
+
   const session = await requireSession()
   if (session.user.role !== "admin") {
-    redirect({ href: "/dashboard", locale: "en" })
+    redirect({ href: "/dashboard", locale: locale as Locale })
   }
 
   let users: UserRow[] = []

--- a/app/[locale]/(admin)/admin/users/page.tsx
+++ b/app/[locale]/(admin)/admin/users/page.tsx
@@ -97,7 +97,8 @@ export default function AdminUsersPage() {
       }
       if (data) {
         // Full reload required to reset all client-side auth state after impersonation
-        window.location.href = "/dashboard"
+        const currentLocale = window.location.pathname.split("/")[1] || "en"
+        window.location.href = `/${currentLocale}/dashboard`
       }
     } catch (error) {
       clientLogger.error("Failed to impersonate user", {

--- a/app/[locale]/(auth)/2fa/page.tsx
+++ b/app/[locale]/(auth)/2fa/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react"
 import { Locale } from "next-intl"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 import type { Metadata } from "next"
 
 import { TwoFactorForm } from "./two-factor-form"
@@ -22,7 +22,14 @@ export async function generateMetadata({
   }
 }
 
-export default function TwoFactorPage() {
+export default async function TwoFactorPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale as Locale)
+
   return (
     <Suspense
       fallback={

--- a/app/[locale]/(auth)/2fa/two-factor-form.tsx
+++ b/app/[locale]/(auth)/2fa/two-factor-form.tsx
@@ -21,7 +21,7 @@ import { Label } from "@/components/ui/label"
 type VerificationMethod = "totp" | "backup"
 
 export function TwoFactorForm() {
-  const t = useTranslations()
+  const t = useTranslations("auth.twoFactor")
   const router = useRouter()
 
   const [method, setMethod] = useState<VerificationMethod>("totp")
@@ -37,7 +37,7 @@ export function TwoFactorForm() {
     const normalized = code.trim()
 
     if (!normalized) {
-      setError(t("auth.twoFactor.enterCode"))
+      setError(t("enterCode"))
       return
     }
 
@@ -50,7 +50,7 @@ export function TwoFactorForm() {
       })
 
       if (verifyError) {
-        setError(t("auth.twoFactor.invalidAuthenticator"))
+        setError(t("invalidAuthenticator"))
         setIsLoading(false)
         return
       }
@@ -62,7 +62,7 @@ export function TwoFactorForm() {
         })
 
       if (verifyError) {
-        setError(t("auth.twoFactor.invalidBackup"))
+        setError(t("invalidBackup"))
         setIsLoading(false)
         return
       }
@@ -75,10 +75,8 @@ export function TwoFactorForm() {
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
-            {t("auth.twoFactor.title")}
-          </CardTitle>
-          <CardDescription>{t("auth.twoFactor.description")}</CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <form onSubmit={handleVerify}>
           <CardContent className="space-y-4">
@@ -99,7 +97,7 @@ export function TwoFactorForm() {
                 }}
                 disabled={isLoading}
               >
-                {t("auth.twoFactor.authenticator")}
+                {t("authenticator")}
               </Button>
               <Button
                 type="button"
@@ -111,15 +109,15 @@ export function TwoFactorForm() {
                 }}
                 disabled={isLoading}
               >
-                {t("auth.twoFactor.backupCode")}
+                {t("backupCode")}
               </Button>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="code">
                 {method === "totp"
-                  ? t("auth.twoFactor.authenticatorCode")
-                  : t("auth.twoFactor.backupCodeLabel")}
+                  ? t("authenticatorCode")
+                  : t("backupCodeLabel")}
               </Label>
               <Input
                 id="code"
@@ -127,8 +125,8 @@ export function TwoFactorForm() {
                 onChange={(event) => setCode(event.target.value)}
                 placeholder={
                   method === "totp"
-                    ? t("auth.twoFactor.authenticatorPlaceholder")
-                    : t("auth.twoFactor.backupPlaceholder")
+                    ? t("authenticatorPlaceholder")
+                    : t("backupPlaceholder")
                 }
                 autoComplete="one-time-code"
                 disabled={isLoading}
@@ -142,20 +140,20 @@ export function TwoFactorForm() {
                 onChange={(event) => setTrustDevice(event.target.checked)}
                 disabled={isLoading}
               />
-              {t("auth.twoFactor.trustDevice")}
+              {t("trustDevice")}
             </label>
           </CardContent>
 
           <CardFooter className="flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("auth.twoFactor.verifyAndContinue")}
+              {t("verifyAndContinue")}
             </Button>
 
             <p className="text-center text-sm text-muted-foreground">
-              {t("auth.twoFactor.differentAccount")}{" "}
+              {t("differentAccount")}{" "}
               <Link href="/sign-in" className="text-primary hover:underline">
-                {t("auth.twoFactor.backToSignIn")}
+                {t("backToSignIn")}
               </Link>
             </p>
           </CardFooter>

--- a/app/[locale]/(auth)/forgot-password/forgot-password-form.tsx
+++ b/app/[locale]/(auth)/forgot-password/forgot-password-form.tsx
@@ -20,7 +20,8 @@ import { authClient } from "@/lib/auth-client"
 import { useForgotPasswordSchema } from "@/lib/schemas"
 
 export function ForgotPasswordForm() {
-  const t = useTranslations()
+  const t = useTranslations("auth.forgotPassword")
+  const tc = useTranslations("common")
   const forgotPasswordSchema = useForgotPasswordSchema()
   const [email, setEmail] = useState("")
   const [isLoading, setIsLoading] = useState(false)
@@ -58,7 +59,7 @@ export function ForgotPasswordForm() {
     )
 
     if (error) {
-      setError(t("auth.forgotPassword.failedToSend"))
+      setError(t("failedToSend"))
     }
     setIsLoading(false)
   }
@@ -69,16 +70,14 @@ export function ForgotPasswordForm() {
         <Card className="w-full max-w-md">
           <CardHeader className="space-y-1">
             <CardTitle className="text-2xl font-bold">
-              {t("auth.forgotPassword.checkEmail")}
+              {t("checkEmail")}
             </CardTitle>
-            <CardDescription>
-              {t("auth.forgotPassword.checkEmailDescription")}
-            </CardDescription>
+            <CardDescription>{t("checkEmailDescription")}</CardDescription>
           </CardHeader>
           <CardFooter>
             <Link href="/sign-in" className="w-full">
               <Button variant="outline" className="w-full">
-                {t("auth.forgotPassword.backToSignIn")}
+                {t("backToSignIn")}
               </Button>
             </Link>
           </CardFooter>
@@ -91,12 +90,8 @@ export function ForgotPasswordForm() {
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
-            {t("auth.forgotPassword.title")}
-          </CardTitle>
-          <CardDescription>
-            {t("auth.forgotPassword.description")}
-          </CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
@@ -106,11 +101,11 @@ export function ForgotPasswordForm() {
               </div>
             )}
             <div className="mb-4 space-y-2">
-              <Label htmlFor="email">{t("common.email")}</Label>
+              <Label htmlFor="email">{tc("email")}</Label>
               <Input
                 id="email"
                 type="email"
-                placeholder={t("auth.forgotPassword.emailPlaceholder")}
+                placeholder={t("emailPlaceholder")}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={isLoading}
@@ -123,12 +118,12 @@ export function ForgotPasswordForm() {
           <CardFooter className="flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("auth.forgotPassword.sendResetLink")}
+              {t("sendResetLink")}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
-              {t("auth.forgotPassword.rememberPassword")}{" "}
+              {t("rememberPassword")}{" "}
               <Link href="/sign-in" className="text-primary hover:underline">
-                {t("auth.forgotPassword.signInLink")}
+                {t("signInLink")}
               </Link>
             </p>
           </CardFooter>

--- a/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/app/[locale]/(auth)/forgot-password/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react"
 import { Locale } from "next-intl"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 import type { Metadata } from "next"
 
 import { ForgotPasswordForm } from "./forgot-password-form"
@@ -22,7 +22,14 @@ export async function generateMetadata({
   }
 }
 
-export default function ForgotPasswordPage() {
+export default async function ForgotPasswordPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale as Locale)
+
   return (
     <Suspense
       fallback={

--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react"
 import { Locale } from "next-intl"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 import type { Metadata } from "next"
 
 import { ResetPasswordForm } from "./reset-password-form"
@@ -23,16 +23,23 @@ export async function generateMetadata({
 }
 
 async function LoadingState() {
-  const t = await getTranslations()
+  const t = await getTranslations("common")
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="text-muted-foreground">{t("common.loading")}</div>
+      <div className="text-muted-foreground">{t("loading")}</div>
     </div>
   )
 }
 
-export default function ResetPasswordPage() {
+export default async function ResetPasswordPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale as Locale)
+
   return (
     <Suspense fallback={<LoadingState />}>
       <ResetPasswordForm />

--- a/app/[locale]/(auth)/reset-password/reset-password-form.tsx
+++ b/app/[locale]/(auth)/reset-password/reset-password-form.tsx
@@ -21,7 +21,8 @@ import { authClient } from "@/lib/auth-client"
 import { useResetPasswordSchema } from "@/lib/schemas"
 
 export function ResetPasswordForm() {
-  const t = useTranslations()
+  const t = useTranslations("auth.resetPassword")
+  const tf = useTranslations("auth.forgotPassword")
   const router = useRouter()
   const resetPasswordSchema = useResetPasswordSchema()
   const searchParams = useSearchParams()
@@ -54,7 +55,7 @@ export function ResetPasswordForm() {
     }
 
     if (!token) {
-      setErrors({ form: t("auth.resetPassword.invalidToken") })
+      setErrors({ form: t("invalidToken") })
       setIsLoading(false)
       return
     }
@@ -66,7 +67,7 @@ export function ResetPasswordForm() {
 
     if (error) {
       setErrors({
-        form: t("auth.resetPassword.failedToReset"),
+        form: t("failedToReset"),
       })
       setIsLoading(false)
     } else {
@@ -80,16 +81,14 @@ export function ResetPasswordForm() {
         <Card className="w-full max-w-md">
           <CardHeader className="space-y-1">
             <CardTitle className="text-2xl font-bold">
-              {t("auth.resetPassword.invalidTokenTitle")}
+              {t("invalidTokenTitle")}
             </CardTitle>
-            <CardDescription>
-              {t("auth.resetPassword.invalidTokenDescription")}
-            </CardDescription>
+            <CardDescription>{t("invalidTokenDescription")}</CardDescription>
           </CardHeader>
           <CardFooter>
             <Link href="/forgot-password" className="w-full">
               <Button variant="outline" className="w-full">
-                {t("auth.resetPassword.requestNewLink")}
+                {t("requestNewLink")}
               </Button>
             </Link>
           </CardFooter>
@@ -102,12 +101,8 @@ export function ResetPasswordForm() {
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
-            {t("auth.resetPassword.title")}
-          </CardTitle>
-          <CardDescription>
-            {t("auth.resetPassword.description")}
-          </CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
@@ -117,13 +112,11 @@ export function ResetPasswordForm() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="password">
-                {t("auth.resetPassword.newPassword")}
-              </Label>
+              <Label htmlFor="password">{t("newPassword")}</Label>
               <Input
                 id="password"
                 type="password"
-                placeholder={t("auth.resetPassword.newPasswordPlaceholder")}
+                placeholder={t("newPasswordPlaceholder")}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 disabled={isLoading}
@@ -133,13 +126,11 @@ export function ResetPasswordForm() {
               )}
             </div>
             <div className="mb-4 space-y-2">
-              <Label htmlFor="confirmPassword">
-                {t("auth.resetPassword.confirmPassword")}
-              </Label>
+              <Label htmlFor="confirmPassword">{t("confirmPassword")}</Label>
               <Input
                 id="confirmPassword"
                 type="password"
-                placeholder={t("auth.resetPassword.confirmPasswordPlaceholder")}
+                placeholder={t("confirmPasswordPlaceholder")}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 disabled={isLoading}
@@ -154,12 +145,12 @@ export function ResetPasswordForm() {
           <CardFooter className="flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("auth.resetPassword.resetButton")}
+              {t("resetButton")}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
-              {t("auth.forgotPassword.rememberPassword")}{" "}
+              {tf("rememberPassword")}{" "}
               <Link href="/sign-in" className="text-primary hover:underline">
-                {t("auth.forgotPassword.signInLink")}
+                {tf("signInLink")}
               </Link>
             </p>
           </CardFooter>

--- a/app/[locale]/(auth)/sign-in/sign-in-form.tsx
+++ b/app/[locale]/(auth)/sign-in/sign-in-form.tsx
@@ -20,7 +20,8 @@ import { authClient } from "@/lib/auth-client"
 import { useSignInSchema } from "@/lib/schemas"
 
 export function SignInForm() {
-  const t = useTranslations()
+  const t = useTranslations("auth.signIn")
+  const tc = useTranslations("common")
   const router = useRouter()
   const signInSchema = useSignInSchema()
   const [email, setEmail] = useState("")
@@ -62,7 +63,7 @@ export function SignInForm() {
     )
 
     if (error) {
-      setErrors({ form: t("auth.signIn.failedToSignIn") })
+      setErrors({ form: t("failedToSignIn") })
       setIsLoading(false)
     }
   }
@@ -77,10 +78,8 @@ export function SignInForm() {
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
-            {t("auth.signIn.title")}
-          </CardTitle>
-          <CardDescription>{t("auth.signIn.description")}</CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
@@ -90,7 +89,7 @@ export function SignInForm() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="email">{t("common.email")}</Label>
+              <Label htmlFor="email">{tc("email")}</Label>
               <Input
                 id="email"
                 type="email"
@@ -104,7 +103,7 @@ export function SignInForm() {
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">{t("common.password")}</Label>
+              <Label htmlFor="password">{tc("password")}</Label>
               <Input
                 id="password"
                 type="password"
@@ -122,14 +121,14 @@ export function SignInForm() {
                 href="/forgot-password"
                 className="text-sm text-muted-foreground hover:text-primary"
               >
-                {t("auth.signIn.forgotPassword")}
+                {t("forgotPassword")}
               </Link>
             </div>
           </CardContent>
           <CardFooter className="mt-6 flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("auth.signIn.signInButton")}
+              {t("signInButton")}
             </Button>
             <div className="relative w-full">
               <div className="absolute inset-0 flex items-center">
@@ -137,7 +136,7 @@ export function SignInForm() {
               </div>
               <div className="relative flex justify-center text-xs uppercase">
                 <span className="bg-card px-2 text-muted-foreground">
-                  {t("common.orContinueWith")}
+                  {tc("orContinueWith")}
                 </span>
               </div>
             </div>
@@ -181,9 +180,9 @@ export function SignInForm() {
               </Button>
             </div>
             <p className="text-center text-sm text-muted-foreground">
-              {t("auth.signIn.noAccount")}{" "}
+              {t("noAccount")}{" "}
               <Link href="/sign-up" className="text-primary hover:underline">
-                {t("auth.signIn.signUpLink")}
+                {t("signUpLink")}
               </Link>
             </p>
           </CardFooter>

--- a/app/[locale]/(auth)/sign-up/sign-up-form.tsx
+++ b/app/[locale]/(auth)/sign-up/sign-up-form.tsx
@@ -20,7 +20,8 @@ import { authClient } from "@/lib/auth-client"
 import { useSignUpSchema } from "@/lib/schemas"
 
 export function SignUpForm() {
-  const t = useTranslations()
+  const t = useTranslations("auth.signUp")
+  const tc = useTranslations("common")
   const router = useRouter()
   const signUpSchema = useSignUpSchema()
   const [name, setName] = useState("")
@@ -65,7 +66,7 @@ export function SignUpForm() {
         },
         onError: (ctx) => {
           setErrors({
-            form: t("auth.signUp.failedToSignUp"),
+            form: t("failedToSignUp"),
           })
           setIsLoading(false)
         },
@@ -83,10 +84,8 @@ export function SignUpForm() {
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">
-            {t("auth.signUp.title")}
-          </CardTitle>
-          <CardDescription>{t("auth.signUp.description")}</CardDescription>
+          <CardTitle className="text-2xl font-bold">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
@@ -96,11 +95,11 @@ export function SignUpForm() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="name">{t("auth.signUp.nameLabel")}</Label>
+              <Label htmlFor="name">{t("nameLabel")}</Label>
               <Input
                 id="name"
                 type="text"
-                placeholder={t("auth.signUp.namePlaceholder")}
+                placeholder={t("namePlaceholder")}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 disabled={isLoading}
@@ -110,11 +109,11 @@ export function SignUpForm() {
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="email">{t("common.email")}</Label>
+              <Label htmlFor="email">{tc("email")}</Label>
               <Input
                 id="email"
                 type="email"
-                placeholder={t("auth.signUp.emailPlaceholder")}
+                placeholder={t("emailPlaceholder")}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={isLoading}
@@ -124,11 +123,11 @@ export function SignUpForm() {
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">{t("auth.signUp.passwordLabel")}</Label>
+              <Label htmlFor="password">{t("passwordLabel")}</Label>
               <Input
                 id="password"
                 type="password"
-                placeholder={t("auth.signUp.passwordPlaceholder")}
+                placeholder={t("passwordPlaceholder")}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 disabled={isLoading}
@@ -139,12 +138,12 @@ export function SignUpForm() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">
-                {t("auth.signUp.confirmPasswordLabel")}
+                {t("confirmPasswordLabel")}
               </Label>
               <Input
                 id="confirmPassword"
                 type="password"
-                placeholder={t("auth.signUp.confirmPasswordPlaceholder")}
+                placeholder={t("confirmPasswordPlaceholder")}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 disabled={isLoading}
@@ -159,7 +158,7 @@ export function SignUpForm() {
           <CardFooter className="mt-6 flex flex-col space-y-4">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("auth.signUp.signUpButton")}
+              {t("signUpButton")}
             </Button>
             <div className="relative w-full">
               <div className="absolute inset-0 flex items-center">
@@ -167,7 +166,7 @@ export function SignUpForm() {
               </div>
               <div className="relative flex justify-center text-xs uppercase">
                 <span className="bg-card px-2 text-muted-foreground">
-                  {t("common.orContinueWith")}
+                  {tc("orContinueWith")}
                 </span>
               </div>
             </div>
@@ -211,9 +210,9 @@ export function SignUpForm() {
               </Button>
             </div>
             <p className="text-center text-sm text-muted-foreground">
-              {t("auth.signUp.hasAccount")}{" "}
+              {t("hasAccount")}{" "}
               <Link href="/sign-in" className="text-primary hover:underline">
-                {t("auth.signUp.signInLink")}
+                {t("signInLink")}
               </Link>
             </p>
           </CardFooter>

--- a/app/[locale]/(auth)/verification-sent/page.tsx
+++ b/app/[locale]/(auth)/verification-sent/page.tsx
@@ -37,7 +37,7 @@ export default async function VerificationSentPage({
   const { locale } = await params
   setRequestLocale(locale as Locale)
 
-  const t = await getTranslations()
+  const t = await getTranslations("auth.verificationSent")
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -49,22 +49,22 @@ export default async function VerificationSentPage({
             </div>
           </div>
           <CardTitle className="pt-4 text-center text-2xl font-bold">
-            {t("auth.verificationSent.title")}
+            {t("title")}
           </CardTitle>
           <CardDescription className="text-center">
-            {t("auth.verificationSent.description")}
+            {t("description")}
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col items-center space-y-4">
           <p className="text-center text-sm text-muted-foreground">
-            {t("auth.verificationSent.didntReceive")}{" "}
+            {t("didntReceive")}{" "}
             <Link href="/sign-up" className="text-primary hover:underline">
-              {t("auth.verificationSent.tryAgain")}
+              {t("tryAgain")}
             </Link>
           </p>
           <Link href="/sign-in" className="w-full">
             <Button variant="outline" className="w-full">
-              {t("auth.verificationSent.backToSignIn")}
+              {t("backToSignIn")}
             </Button>
           </Link>
         </CardContent>

--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react"
 import { Locale } from "next-intl"
-import { getTranslations } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 import type { Metadata } from "next"
 
 import { VerifyEmailForm } from "./verify-email-form"
@@ -23,16 +23,23 @@ export async function generateMetadata({
 }
 
 async function LoadingState() {
-  const t = await getTranslations()
+  const t = await getTranslations("common")
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="text-muted-foreground">{t("common.loading")}</div>
+      <div className="text-muted-foreground">{t("loading")}</div>
     </div>
   )
 }
 
-export default function VerifyEmailPage() {
+export default async function VerifyEmailPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale as Locale)
+
   return (
     <Suspense fallback={<LoadingState />}>
       <VerifyEmailForm />

--- a/app/[locale]/(auth)/verify-email/verify-email-form.tsx
+++ b/app/[locale]/(auth)/verify-email/verify-email-form.tsx
@@ -18,7 +18,9 @@ import {
 import { authClient } from "@/lib/auth-client"
 
 export function VerifyEmailForm() {
-  const t = useTranslations()
+  const tVerify = useTranslations("auth.verifyEmail")
+  const tLanding = useTranslations("landing")
+  const tCommon = useTranslations("common")
   const searchParams = useSearchParams()
   const token = searchParams.get("token")
 
@@ -31,7 +33,7 @@ export function VerifyEmailForm() {
     const verifyEmail = async () => {
       if (!token) {
         setStatus("error")
-        setMessage(t("auth.verifyEmail.invalidToken"))
+        setMessage(tVerify("invalidToken"))
         return
       }
 
@@ -40,23 +42,23 @@ export function VerifyEmailForm() {
         {
           onSuccess: () => {
             setStatus("success")
-            setMessage(t("auth.verifyEmail.success"))
+            setMessage(tVerify("success"))
           },
           onError: () => {
             setStatus("error")
-            setMessage(t("auth.verifyEmail.failed"))
+            setMessage(tVerify("failed"))
           },
         }
       )
 
       if (error) {
         setStatus("error")
-        setMessage(t("auth.verifyEmail.failed"))
+        setMessage(tVerify("failed"))
       }
     }
 
     verifyEmail()
-  }, [token, t])
+  }, [token, tVerify])
 
   if (status === "loading") {
     return (
@@ -64,11 +66,9 @@ export function VerifyEmailForm() {
         <Card className="w-full max-w-md">
           <CardHeader className="space-y-1">
             <CardTitle className="text-2xl font-bold">
-              {t("auth.verifyEmail.verifying")}
+              {tVerify("verifying")}
             </CardTitle>
-            <CardDescription>
-              {t("auth.verifyEmail.verifyingDescription")}
-            </CardDescription>
+            <CardDescription>{tVerify("verifyingDescription")}</CardDescription>
           </CardHeader>
           <CardContent className="flex justify-center py-6">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -84,19 +84,19 @@ export function VerifyEmailForm() {
         <Card className="w-full max-w-md">
           <CardHeader className="space-y-1">
             <CardTitle className="text-2xl font-bold">
-              {t("auth.verifyEmail.failed")}
+              {tVerify("failed")}
             </CardTitle>
             <CardDescription>{message}</CardDescription>
           </CardHeader>
           <CardFooter className="flex flex-col space-y-2">
             <Link href="/sign-in" className="w-full">
               <Button variant="outline" className="w-full">
-                {t("auth.verifyEmail.goToSignIn")}
+                {tVerify("goToSignIn")}
               </Button>
             </Link>
             <Link href="/" className="w-full">
               <Button variant="ghost" className="w-full">
-                {t("auth.verifyEmail.goHome")}
+                {tVerify("goHome")}
               </Button>
             </Link>
           </CardFooter>
@@ -110,17 +110,17 @@ export function VerifyEmailForm() {
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-green-600">
-            {t("auth.verifyEmail.verified")}
+            {tVerify("verified")}
           </CardTitle>
           <CardDescription>{message}</CardDescription>
         </CardHeader>
         <CardFooter className="flex flex-col space-y-2">
           <Link href="/dashboard" className="w-full">
-            <Button className="w-full">{t("landing.goToDashboard")}</Button>
+            <Button className="w-full">{tLanding("goToDashboard")}</Button>
           </Link>
           <Link href="/sign-in" className="w-full">
             <Button variant="outline" className="w-full">
-              {t("common.signIn")}
+              {tCommon("signIn")}
             </Button>
           </Link>
         </CardFooter>

--- a/app/[locale]/(dashboard)/_components/app-sidebar.tsx
+++ b/app/[locale]/(dashboard)/_components/app-sidebar.tsx
@@ -28,34 +28,34 @@ export function AppSidebar({
 }: React.ComponentProps<typeof Sidebar> & {
   user: { name: string; email: string; avatar: string }
 }) {
-  const t = useTranslations()
+  const t = useTranslations("sidebar")
 
   const data = {
     navMain: [
       {
-        title: t("sidebar.dashboard"),
+        title: t("dashboard"),
         url: `/dashboard`,
         icon: LayoutDashboard,
       },
       {
-        title: t("sidebar.account"),
+        title: t("account"),
         url: `/account`,
         icon: User,
       },
     ],
     navSecondary: [
       {
-        title: t("sidebar.home"),
+        title: t("home"),
         url: `/`,
         icon: Home,
       },
       {
-        title: t("sidebar.settings"),
+        title: t("settings"),
         url: `/dashboard`,
         icon: Settings,
       },
       {
-        title: t("sidebar.getHelp"),
+        title: t("getHelp"),
         url: `/dashboard`,
         icon: HelpCircle,
       },
@@ -74,7 +74,7 @@ export function AppSidebar({
               <Link href="/dashboard">
                 <Shield className="size-5!" />
                 <span className="text-base font-semibold">
-                  {t("sidebar.myAccount")}
+                  {t("myAccount")}
                 </span>
               </Link>
             </SidebarMenuButton>

--- a/app/[locale]/(dashboard)/account/account-tabs.tsx
+++ b/app/[locale]/(dashboard)/account/account-tabs.tsx
@@ -19,7 +19,8 @@ import { TwoFactorManager } from "./two-factor-manager"
 import { PasskeyManager } from "./passkey-manager"
 
 export function AccountTabs() {
-  const t = useTranslations()
+  const tAccount = useTranslations("dashboard.account")
+  const tCommon = useTranslations("common")
   const { data: session, isPending } = authClient.useSession()
 
   if (isPending) {
@@ -27,7 +28,7 @@ export function AccountTabs() {
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="mt-4 text-muted-foreground">{t("common.loading")}</p>
+          <p className="mt-4 text-muted-foreground">{tCommon("loading")}</p>
         </div>
       </div>
     )
@@ -38,16 +39,14 @@ export function AccountTabs() {
       <div className="flex min-h-screen items-center justify-center bg-background">
         <Card className="w-full max-w-md">
           <CardHeader>
-            <CardTitle>{t("dashboard.account.notSignedIn")}</CardTitle>
+            <CardTitle>{tAccount("notSignedIn")}</CardTitle>
             <CardDescription>
-              {t("dashboard.account.notSignedInDescription")}
+              {tAccount("notSignedInDescription")}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/sign-in">
-              <Button className="w-full">
-                {t("dashboard.account.signIn")}
-              </Button>
+              <Button className="w-full">{tAccount("signIn")}</Button>
             </Link>
           </CardContent>
         </Card>
@@ -61,47 +60,43 @@ export function AccountTabs() {
     <div className="px-4 lg:px-6">
       <Tabs defaultValue="profile" className="mx-auto max-w-4xl">
         <TabsList className="grid w-full grid-cols-4">
-          <TabsTrigger value="profile">
-            {t("dashboard.account.tabs.profile")}
-          </TabsTrigger>
+          <TabsTrigger value="profile">{tAccount("tabs.profile")}</TabsTrigger>
           <TabsTrigger value="password">
-            {t("dashboard.account.tabs.password")}
+            {tAccount("tabs.password")}
           </TabsTrigger>
           <TabsTrigger value="two-factor">
-            {t("dashboard.account.tabs.twoFactor")}
+            {tAccount("tabs.twoFactor")}
           </TabsTrigger>
           <TabsTrigger value="passkeys">
-            {t("dashboard.account.tabs.passkeys")}
+            {tAccount("tabs.passkeys")}
           </TabsTrigger>
         </TabsList>
 
         <TabsContent value="profile" className="mt-6">
           <Card>
             <CardHeader>
-              <CardTitle>{t("dashboard.account.profileInfo.title")}</CardTitle>
+              <CardTitle>{tAccount("profileInfo.title")}</CardTitle>
               <CardDescription>
-                {t("dashboard.account.profileInfo.description")}
+                {tAccount("profileInfo.description")}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid gap-2">
-                <Label>{t("common.name")}</Label>
+                <Label>{tCommon("name")}</Label>
                 <p className="rounded-md border bg-muted/50 px-3 py-2">
-                  {user.name || t("dashboard.account.profileInfo.notSet")}
+                  {user.name || tAccount("profileInfo.notSet")}
                 </p>
               </div>
               <div className="grid gap-2">
-                <Label>{t("common.email")}</Label>
+                <Label>{tCommon("email")}</Label>
                 <p className="rounded-md border bg-muted/50 px-3 py-2">
                   {user.email}
                 </p>
               </div>
               <div className="grid gap-2">
-                <Label>
-                  {t("dashboard.account.profileInfo.emailVerified")}
-                </Label>
+                <Label>{tAccount("profileInfo.emailVerified")}</Label>
                 <p className="rounded-md border bg-muted/50 px-3 py-2">
-                  {user.emailVerified ? t("common.yes") : t("common.no")}
+                  {user.emailVerified ? tCommon("yes") : tCommon("no")}
                 </p>
               </div>
             </CardContent>

--- a/app/[locale]/(dashboard)/account/passkey-manager.tsx
+++ b/app/[locale]/(dashboard)/account/passkey-manager.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/card"
 
 export function PasskeyManager() {
-  const t = useTranslations()
+  const t = useTranslations("dashboard.account")
   const { data: session } = authClient.useSession()
 
   const [isAddingPasskey, setIsAddingPasskey] = useState(false)
@@ -33,12 +33,12 @@ export function PasskeyManager() {
       })
 
       if (error) {
-        setPasskeyError(t("dashboard.account.failedToAddPasskey"))
+        setPasskeyError(t("failedToAddPasskey"))
       } else {
         setPasskeySuccess(true)
       }
     } catch {
-      setPasskeyError(t("dashboard.account.failedToAddPasskey"))
+      setPasskeyError(t("failedToAddPasskey"))
     } finally {
       setIsAddingPasskey(false)
     }
@@ -47,10 +47,8 @@ export function PasskeyManager() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t("dashboard.account.passkeysSection.title")}</CardTitle>
-        <CardDescription>
-          {t("dashboard.account.passkeysSection.description")}
-        </CardDescription>
+        <CardTitle>{t("passkeysSection.title")}</CardTitle>
+        <CardDescription>{t("passkeysSection.description")}</CardDescription>
       </CardHeader>
       <CardContent>
         {passkeyError && (
@@ -60,7 +58,7 @@ export function PasskeyManager() {
         )}
         {passkeySuccess && (
           <div className="mb-4 rounded-md bg-green-500/10 p-3 text-sm text-green-600">
-            {t("dashboard.account.passkeysSection.success")}
+            {t("passkeysSection.success")}
           </div>
         )}
         <div className="flex items-center justify-between">
@@ -69,11 +67,9 @@ export function PasskeyManager() {
               <KeyRound className="h-6 w-6" />
             </div>
             <div>
-              <p className="font-medium">
-                {t("dashboard.account.passkeysSection.subtitle")}
-              </p>
+              <p className="font-medium">{t("passkeysSection.subtitle")}</p>
               <p className="text-sm text-muted-foreground">
-                {t("dashboard.account.passkeysSection.usePasskeys")}
+                {t("passkeysSection.usePasskeys")}
               </p>
             </div>
           </div>
@@ -88,7 +84,7 @@ export function PasskeyManager() {
             ) : (
               <Lock className="mr-2 h-4 w-4" />
             )}
-            {t("dashboard.account.passkeysSection.addPasskey")}
+            {t("passkeysSection.addPasskey")}
           </Button>
         </div>
       </CardContent>

--- a/app/[locale]/(dashboard)/account/password-change-form.tsx
+++ b/app/[locale]/(dashboard)/account/password-change-form.tsx
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 export function PasswordChangeForm() {
-  const t = useTranslations()
+  const t = useTranslations("dashboard.account")
   const changePasswordSchema = useChangePasswordSchema()
 
   const [currentPassword, setCurrentPassword] = useState("")
@@ -52,7 +52,7 @@ export function PasswordChangeForm() {
         fieldErrors.confirmPassword ||
           fieldErrors.newPassword ||
           fieldErrors.currentPassword ||
-          t("dashboard.account.validationFailed")
+          t("validationFailed")
       )
       return
     }
@@ -65,7 +65,7 @@ export function PasswordChangeForm() {
     })
 
     if (error) {
-      setPasswordError(t("dashboard.account.failedToChangePassword"))
+      setPasswordError(t("failedToChangePassword"))
     } else {
       setPasswordSuccess(true)
       setCurrentPassword("")
@@ -79,10 +79,8 @@ export function PasswordChangeForm() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t("dashboard.account.changePassword.title")}</CardTitle>
-        <CardDescription>
-          {t("dashboard.account.changePassword.description")}
-        </CardDescription>
+        <CardTitle>{t("changePassword.title")}</CardTitle>
+        <CardDescription>{t("changePassword.description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleChangePassword} className="space-y-4">
@@ -93,12 +91,12 @@ export function PasswordChangeForm() {
           )}
           {passwordSuccess && (
             <div className="rounded-md bg-green-500/10 p-3 text-sm text-green-600">
-              {t("dashboard.account.changePassword.success")}
+              {t("changePassword.success")}
             </div>
           )}
           <div className="grid gap-2">
             <Label htmlFor="currentPassword">
-              {t("dashboard.account.changePassword.currentPassword")}
+              {t("changePassword.currentPassword")}
             </Label>
             <Input
               id="currentPassword"
@@ -111,7 +109,7 @@ export function PasswordChangeForm() {
           </div>
           <div className="grid gap-2">
             <Label htmlFor="newPassword">
-              {t("dashboard.account.changePassword.newPassword")}
+              {t("changePassword.newPassword")}
             </Label>
             <Input
               id="newPassword"
@@ -124,7 +122,7 @@ export function PasswordChangeForm() {
           </div>
           <div className="grid gap-2">
             <Label htmlFor="confirmPassword">
-              {t("dashboard.account.changePassword.confirmNewPassword")}
+              {t("changePassword.confirmNewPassword")}
             </Label>
             <Input
               id="confirmPassword"
@@ -139,7 +137,7 @@ export function PasswordChangeForm() {
             {isChangingPassword && (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             )}
-            {t("dashboard.account.changePassword.changeButton")}
+            {t("changePassword.changeButton")}
           </Button>
         </form>
       </CardContent>

--- a/app/[locale]/(dashboard)/account/two-factor-manager.tsx
+++ b/app/[locale]/(dashboard)/account/two-factor-manager.tsx
@@ -28,7 +28,8 @@ import {
 } from "@/components/ui/alert-dialog"
 
 export function TwoFactorManager() {
-  const t = useTranslations()
+  const tAccount = useTranslations("dashboard.account")
+  const tCommon = useTranslations("common")
   const { data: session } = authClient.useSession()
 
   const sessionTwoFactor = Boolean(session?.user?.twoFactorEnabled)
@@ -60,7 +61,7 @@ export function TwoFactorManager() {
       if (!error) {
         setTwoFactorEnabled(false)
       } else {
-        setTwoFactorError(t("dashboard.account.failedToDisable2FA"))
+        setTwoFactorError(tAccount("failedToDisable2FA"))
       }
     } else {
       const { data, error } = await authClient.twoFactor.enable({
@@ -73,7 +74,7 @@ export function TwoFactorManager() {
         setCopiedBackupCodes(false)
         setShowTwoFactorSetup(true)
       } else {
-        setTwoFactorError(t("dashboard.account.failedToEnable2FA"))
+        setTwoFactorError(tAccount("failedToEnable2FA"))
       }
     }
 
@@ -89,7 +90,7 @@ export function TwoFactorManager() {
       await navigator.clipboard.writeText(backupCodes.join("\n"))
       setCopiedBackupCodes(true)
     } catch {
-      setTwoFactorError(t("dashboard.account.couldNotCopy"))
+      setTwoFactorError(tAccount("couldNotCopy"))
     }
   }
 
@@ -103,9 +104,9 @@ export function TwoFactorManager() {
     <>
       <Card>
         <CardHeader>
-          <CardTitle>{t("dashboard.account.twoFactorSection.title")}</CardTitle>
+          <CardTitle>{tAccount("twoFactorSection.title")}</CardTitle>
           <CardDescription>
-            {t("dashboard.account.twoFactorSection.description")}
+            {tAccount("twoFactorSection.description")}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -121,12 +122,12 @@ export function TwoFactorManager() {
               </div>
               <div>
                 <p className="font-medium">
-                  {t("dashboard.account.twoFactorSection.title")}
+                  {tAccount("twoFactorSection.title")}
                 </p>
                 <p className="text-sm text-muted-foreground">
                   {twoFactorEnabled
-                    ? t("dashboard.account.twoFactorSection.enabled")
-                    : t("dashboard.account.twoFactorSection.disabled")}
+                    ? tAccount("twoFactorSection.enabled")
+                    : tAccount("twoFactorSection.disabled")}
                 </p>
               </div>
             </div>
@@ -140,12 +141,8 @@ export function TwoFactorManager() {
             <div className="mt-4 space-y-2">
               <Label htmlFor="twoFactorPassword">
                 {twoFactorEnabled
-                  ? t(
-                      "dashboard.account.twoFactorSection.enterPasswordToDisable"
-                    )
-                  : t(
-                      "dashboard.account.twoFactorSection.enterPasswordToEnable"
-                    )}
+                  ? tAccount("twoFactorSection.enterPasswordToDisable")
+                  : tAccount("twoFactorSection.enterPasswordToEnable")}
               </Label>
               <div className="flex gap-2">
                 <Input
@@ -153,9 +150,7 @@ export function TwoFactorManager() {
                   type="password"
                   value={passwordPromptValue}
                   onChange={(e) => setPasswordPromptValue(e.target.value)}
-                  placeholder={t(
-                    "dashboard.account.twoFactorSection.passwordPlaceholder"
-                  )}
+                  placeholder={tAccount("twoFactorSection.passwordPlaceholder")}
                 />
                 <Button
                   onClick={handle2FAWithPassword}
@@ -164,21 +159,21 @@ export function TwoFactorManager() {
                   {isLoading2FA && (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   )}
-                  {t("dashboard.account.twoFactorSection.confirm")}
+                  {tAccount("twoFactorSection.confirm")}
                 </Button>
                 <Button
                   variant="outline"
                   onClick={() => setShowPasswordPrompt(false)}
                   disabled={isLoading2FA}
                 >
-                  {t("dashboard.account.twoFactorSection.cancel")}
+                  {tAccount("twoFactorSection.cancel")}
                 </Button>
               </div>
             </div>
           )}
           <Separator className="my-4" />
           <p className="text-sm text-muted-foreground">
-            {t("dashboard.account.twoFactorSection.enableDescription")}
+            {tAccount("twoFactorSection.enableDescription")}
           </p>
         </CardContent>
       </Card>
@@ -196,10 +191,10 @@ export function TwoFactorManager() {
         <AlertDialogContent className="max-w-lg">
           <AlertDialogHeader className="items-start text-left">
             <AlertDialogTitle>
-              {t("dashboard.account.twoFactorSetup.dialogTitle")}
+              {tAccount("twoFactorSetup.dialogTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t("dashboard.account.twoFactorSetup.dialogDescription")}
+              {tAccount("twoFactorSetup.dialogDescription")}
             </AlertDialogDescription>
           </AlertDialogHeader>
 
@@ -209,21 +204,21 @@ export function TwoFactorManager() {
                 <QRCodeSVG value={totpURI} size={180} includeMargin />
               ) : (
                 <p className="text-sm text-muted-foreground">
-                  {t("dashboard.account.twoFactorSetup.totpError")}
+                  {tAccount("twoFactorSetup.totpError")}
                 </p>
               )}
               <p className="text-center text-xs text-muted-foreground">
-                {t("dashboard.account.twoFactorSetup.scanHint")}
+                {tAccount("twoFactorSetup.scanHint")}
               </p>
               <p className="w-full overflow-auto rounded bg-muted px-3 py-2 font-mono text-xs">
-                {totpURI || t("dashboard.account.twoFactorSetup.noTotpUri")}
+                {totpURI || tAccount("twoFactorSetup.noTotpUri")}
               </p>
             </div>
 
             <div className="rounded-md border p-4">
               <div className="mb-3 flex items-center justify-between">
                 <p className="font-medium">
-                  {t("dashboard.account.twoFactorSetup.backupCodes")}
+                  {tAccount("twoFactorSetup.backupCodes")}
                 </p>
                 <Button
                   type="button"
@@ -237,7 +232,7 @@ export function TwoFactorManager() {
                   ) : (
                     <Copy className="mr-2 h-4 w-4" />
                   )}
-                  {copiedBackupCodes ? t("common.copied") : t("common.copyAll")}
+                  {copiedBackupCodes ? tCommon("copied") : tCommon("copyAll")}
                 </Button>
               </div>
               <div className="grid grid-cols-2 gap-2">
@@ -252,7 +247,7 @@ export function TwoFactorManager() {
                   ))
                 ) : (
                   <p className="col-span-2 text-sm text-muted-foreground">
-                    {t("dashboard.account.twoFactorSetup.noBackupCodes")}
+                    {tAccount("twoFactorSetup.noBackupCodes")}
                   </p>
                 )}
               </div>
@@ -266,19 +261,19 @@ export function TwoFactorManager() {
                   setSavedRecoveryCodes(event.target.checked)
                 }
               />
-              {t("dashboard.account.twoFactorSetup.savedCodes")}
+              {tAccount("twoFactorSetup.savedCodes")}
             </label>
           </div>
 
           <AlertDialogFooter className="sm:justify-between">
             <p className="text-xs text-muted-foreground">
-              {t("dashboard.account.twoFactorSetup.regenerateHint")}
+              {tAccount("twoFactorSetup.regenerateHint")}
             </p>
             <Button
               onClick={handleCloseTwoFactorSetup}
               disabled={!savedRecoveryCodes}
             >
-              {t("dashboard.account.twoFactorSetup.continueToAccount")}
+              {tAccount("twoFactorSetup.continueToAccount")}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -41,7 +41,7 @@ export default async function DashboardPage({
   const { locale } = await params
   setRequestLocale(locale as Locale)
 
-  const t = await getTranslations()
+  const t = await getTranslations("dashboard")
   const session = await getSession()
 
   const user = session?.user
@@ -64,13 +64,9 @@ export default async function DashboardPage({
           <CardHeader>
             <div className="flex items-center gap-2">
               <User className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-lg">
-                {t("dashboard.profile.title")}
-              </CardTitle>
+              <CardTitle className="text-lg">{t("profile.title")}</CardTitle>
             </div>
-            <CardDescription>
-              {t("dashboard.profile.description")}
-            </CardDescription>
+            <CardDescription>{t("profile.description")}</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="flex items-center gap-4">
@@ -88,13 +84,9 @@ export default async function DashboardPage({
                 </p>
                 <div className="flex gap-2">
                   {currentUser.emailVerified ? (
-                    <Badge variant="secondary">
-                      {t("dashboard.profile.verified")}
-                    </Badge>
+                    <Badge variant="secondary">{t("profile.verified")}</Badge>
                   ) : (
-                    <Badge variant="outline">
-                      {t("dashboard.profile.unverified")}
-                    </Badge>
+                    <Badge variant="outline">{t("profile.unverified")}</Badge>
                   )}
                 </div>
               </div>
@@ -106,30 +98,26 @@ export default async function DashboardPage({
           <CardHeader>
             <div className="flex items-center gap-2">
               <Shield className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-lg">
-                {t("dashboard.security.title")}
-              </CardTitle>
+              <CardTitle className="text-lg">{t("security.title")}</CardTitle>
             </div>
-            <CardDescription>
-              {t("dashboard.security.description")}
-            </CardDescription>
+            <CardDescription>{t("security.description")}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">
-                {t("dashboard.security.twoFactor")}
+                {t("security.twoFactor")}
               </span>
               <Badge
                 variant={currentUser.twoFactorEnabled ? "secondary" : "outline"}
               >
                 {currentUser.twoFactorEnabled
-                  ? t("dashboard.security.enabled")
-                  : t("dashboard.security.disabled")}
+                  ? t("security.enabled")
+                  : t("security.disabled")}
               </Badge>
             </div>
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">
-                {t("dashboard.security.userId")}
+                {t("security.userId")}
               </span>
               <span className="font-mono text-xs">
                 {currentUser.id.slice(0, 8)}...
@@ -137,7 +125,7 @@ export default async function DashboardPage({
             </div>
             <Link href="/account">
               <Button variant="outline" size="sm" className="w-full">
-                {t("dashboard.security.manageSecurity")}
+                {t("security.manageSecurity")}
               </Button>
             </Link>
           </CardContent>
@@ -148,24 +136,22 @@ export default async function DashboardPage({
             <div className="flex items-center gap-2">
               <Settings className="h-5 w-5 text-muted-foreground" />
               <CardTitle className="text-lg">
-                {t("dashboard.quickActions.title")}
+                {t("quickActions.title")}
               </CardTitle>
             </div>
-            <CardDescription>
-              {t("dashboard.quickActions.description")}
-            </CardDescription>
+            <CardDescription>{t("quickActions.description")}</CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col gap-2">
             <Link href="/account">
               <Button variant="outline" className="w-full justify-start">
                 <User className="mr-2 h-4 w-4" />
-                {t("dashboard.quickActions.accountSettings")}
+                {t("quickActions.accountSettings")}
               </Button>
             </Link>
             <Link href="/account">
               <Button variant="outline" className="w-full justify-start">
                 <Shield className="mr-2 h-4 w-4" />
-                {t("dashboard.quickActions.securitySettings")}
+                {t("quickActions.securitySettings")}
               </Button>
             </Link>
           </CardContent>

--- a/app/[locale]/(dashboard)/layout.tsx
+++ b/app/[locale]/(dashboard)/layout.tsx
@@ -1,15 +1,10 @@
 import { Locale } from "next-intl"
-import { setRequestLocale } from "next-intl/server"
+import { setRequestLocale, getTranslations } from "next-intl/server"
 import { requireSession } from "@/lib/auth-session"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
 import { AppSidebar } from "./_components/app-sidebar"
 import { SiteHeader } from "@/components/sidebar"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
-
-const routeLabels: Record<string, string> = {
-  dashboard: "Dashboard",
-  account: "Account",
-}
 
 export default async function DashboardLayout({
   children,
@@ -20,6 +15,12 @@ export default async function DashboardLayout({
 }) {
   const { locale } = await params
   setRequestLocale(locale as Locale)
+
+  const t = await getTranslations("routeLabels")
+  const routeLabels: Record<string, string> = {
+    dashboard: t("dashboard"),
+    account: t("account"),
+  }
 
   const session = await requireSession()
 

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const t = useTranslations("common")
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
+      <h2 className="text-2xl font-bold">{t("error")}</h2>
+      <p className="mt-2 text-muted-foreground">{error.message}</p>
+      <button
+        onClick={reset}
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+      >
+        {t("tryAgain")}
+      </button>
+    </div>
+  )
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,11 +1,23 @@
+import { Geist, Geist_Mono } from "next/font/google"
 import { Locale, NextIntlClientProvider, hasLocale } from "next-intl"
 import { setRequestLocale, getTranslations } from "next-intl/server"
 import { notFound } from "next/navigation"
 import type { Metadata } from "next"
 
 import { routing } from "@/lib/routing"
+import { cn } from "@/lib/utils"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
+
+const fontSans = Geist({
+  subsets: ["latin"],
+  variable: "--font-sans",
+})
+
+const fontMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+})
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }))
@@ -48,10 +60,23 @@ export default async function LocaleLayout({
   setRequestLocale(locale)
 
   return (
-    <NextIntlClientProvider>
-      <ThemeProvider>
-        <TooltipProvider>{children}</TooltipProvider>
-      </ThemeProvider>
-    </NextIntlClientProvider>
+    <html
+      lang={locale}
+      suppressHydrationWarning
+      className={cn(
+        "antialiased",
+        fontMono.variable,
+        "font-sans",
+        fontSans.variable
+      )}
+    >
+      <body>
+        <NextIntlClientProvider>
+          <ThemeProvider>
+            <TooltipProvider>{children}</TooltipProvider>
+          </ThemeProvider>
+        </NextIntlClientProvider>
+      </body>
+    </html>
   )
 }

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -3,12 +3,12 @@
 import { useTranslations } from "next-intl"
 
 export default function NotFound() {
-  const t = useTranslations()
+  const t = useTranslations("common")
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
       <h1 className="text-4xl font-bold">404</h1>
-      <p className="mt-2 text-muted-foreground">{t("common.pageNotFound")}</p>
+      <p className="mt-2 text-muted-foreground">{t("pageNotFound")}</p>
     </div>
   )
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -41,7 +41,8 @@ export default async function Page({
   const { locale } = await params
   setRequestLocale(locale as Locale)
 
-  const t = await getTranslations()
+  const tLanding = await getTranslations("landing")
+  const tCommon = await getTranslations("common")
   const session = await getSession()
   const user = session?.user
 
@@ -52,26 +53,26 @@ export default async function Page({
       <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-16 md:px-6">
         <header className="space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight">
-            {t("landing.title")}
+            {tLanding("title")}
           </h1>
           <p className="text-sm text-muted-foreground">
-            {t("landing.description")}
+            {tLanding("description")}
           </p>
         </header>
 
         {!user ? (
           <Card>
             <CardHeader>
-              <CardTitle>{t("landing.notSignedIn")}</CardTitle>
+              <CardTitle>{tLanding("notSignedIn")}</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-col gap-4 sm:flex-row">
               <Link href="/sign-in">
                 <Button>
-                  {t("common.signIn")} <ArrowRight className="ml-2 h-4 w-4" />
+                  {tCommon("signIn")} <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
               </Link>
               <Link href="/sign-up">
-                <Button variant="outline">{t("landing.createAccount")}</Button>
+                <Button variant="outline">{tLanding("createAccount")}</Button>
               </Link>
             </CardContent>
           </Card>
@@ -83,10 +84,10 @@ export default async function Page({
                   <ShieldAlert className="mt-0.5 h-5 w-5 text-amber-700 dark:text-amber-400" />
                   <div className="space-y-1">
                     <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
-                      {t("landing.verifyEmail")}
+                      {tLanding("verifyEmail")}
                     </p>
                     <p className="text-sm text-amber-800/90 dark:text-amber-300">
-                      {t("landing.verifyEmailDescription")}
+                      {tLanding("verifyEmailDescription")}
                     </p>
                   </div>
                 </CardContent>
@@ -95,12 +96,12 @@ export default async function Page({
 
             <Card>
               <CardHeader>
-                <CardTitle>{t("landing.currentSession")}</CardTitle>
+                <CardTitle>{tLanding("currentSession")}</CardTitle>
               </CardHeader>
               <CardContent className="grid gap-4 sm:grid-cols-2">
                 <StatusRow
                   icon={<Mail className="h-4 w-4" />}
-                  label={t("common.email")}
+                  label={tCommon("email")}
                   value={user.email}
                 />
                 <StatusRow
@@ -111,31 +112,29 @@ export default async function Page({
                       <ShieldAlert className="h-4 w-4" />
                     )
                   }
-                  label={t("landing.emailVerified")}
-                  value={user.emailVerified ? t("common.yes") : t("common.no")}
+                  label={tLanding("emailVerified")}
+                  value={user.emailVerified ? tCommon("yes") : tCommon("no")}
                   tone={user.emailVerified ? "ok" : "warn"}
                 />
                 <StatusRow
                   icon={<UserCog className="h-4 w-4" />}
-                  label={t("landing.role")}
-                  value={user.role || t("common.defaultRole")}
+                  label={tLanding("role")}
+                  value={user.role || tCommon("defaultRole")}
                 />
                 <StatusRow
                   icon={<ShieldAlert className="h-4 w-4" />}
-                  label={t("landing.banned")}
-                  value={user.banned ? t("common.yes") : t("common.no")}
+                  label={tLanding("banned")}
+                  value={user.banned ? tCommon("yes") : tCommon("no")}
                   tone={user.banned ? "warn" : "ok"}
                 />
                 <StatusRow
                   icon={<ShieldCheck className="h-4 w-4" />}
-                  label={t("landing.twoFactorEnabled")}
-                  value={
-                    user.twoFactorEnabled ? t("common.yes") : t("common.no")
-                  }
+                  label={tLanding("twoFactorEnabled")}
+                  value={user.twoFactorEnabled ? tCommon("yes") : tCommon("no")}
                 />
                 <StatusRow
                   icon={<ShieldCheck className="h-4 w-4" />}
-                  label={t("landing.userId")}
+                  label={tLanding("userId")}
                   value={user.id}
                 />
               </CardContent>
@@ -143,7 +142,7 @@ export default async function Page({
 
             <div className="flex flex-wrap gap-3">
               <Link href="/dashboard">
-                <Button>{t("landing.goToDashboard")}</Button>
+                <Button>{tLanding("goToDashboard")}</Button>
               </Link>
             </div>
           </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,36 +1,10 @@
-import { Geist, Geist_Mono } from "next/font/google"
-
 import "./globals.css"
-import { cn } from "@/lib/utils"
 import "@/lib/logger"
-
-const fontSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-sans",
-})
-
-const fontMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-mono",
-})
 
 export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return (
-    <html
-      lang="en"
-      suppressHydrationWarning
-      className={cn(
-        "antialiased",
-        fontMono.variable,
-        "font-sans",
-        fontSans.variable
-      )}
-    >
-      <body>{children}</body>
-    </html>
-  )
+  return children
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import Error from "next/error"
+
+export default function NotFound() {
+  return (
+    <html lang="en">
+      <body>
+        <Error statusCode={404} />
+      </body>
+    </html>
+  )
+}

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button"
 import { AlertTriangle, LogOut, Loader2 } from "lucide-react"
 
 export function ImpersonationBanner({ session }: { session: Session | null }) {
-  const t = useTranslations()
+  const t = useTranslations("impersonation")
   const router = useRouter()
   const [isStopping, setIsStopping] = useState(false)
 
@@ -37,7 +37,7 @@ export function ImpersonationBanner({ session }: { session: Session | null }) {
     <div className="sticky top-0 z-[60] flex items-center justify-center gap-4 bg-amber-500 px-4 py-2 text-sm font-medium text-amber-950 dark:bg-amber-600 dark:text-amber-50">
       <AlertTriangle className="h-4 w-4 shrink-0" />
       <span>
-        {t("impersonation.impersonating")}{" "}
+        {t("impersonating")}{" "}
         <strong>{session?.user?.name || session?.user?.email}</strong>
       </span>
       <Button
@@ -52,7 +52,7 @@ export function ImpersonationBanner({ session }: { session: Session | null }) {
         ) : (
           <LogOut className="mr-1 h-3 w-3" />
         )}
-        {t("impersonation.stopImpersonating")}
+        {t("stopImpersonating")}
       </Button>
     </div>
   )

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -29,7 +29,8 @@ import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { ImpersonationBanner } from "@/components/impersonation-banner"
 
 export function Navbar({ session }: { session: Session | null }) {
-  const t = useTranslations()
+  const tCommon = useTranslations("common")
+  const tNavbar = useTranslations("navbar")
   const pathname = usePathname()
   const user = session?.user
   const router = useRouter()
@@ -60,7 +61,7 @@ export function Navbar({ session }: { session: Session | null }) {
         <div className="container mx-auto flex h-14 items-center justify-between px-4">
           <Link href="/" className="flex items-center gap-2 font-semibold">
             <Home className="h-4 w-4" />
-            <span>{t("common.home")}</span>
+            <span>{tCommon("home")}</span>
           </Link>
 
           <div className="flex items-center gap-2">
@@ -70,7 +71,7 @@ export function Navbar({ session }: { session: Session | null }) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  aria-label={t("common.changeLanguage")}
+                  aria-label={tCommon("changeLanguage")}
                 >
                   <Globe className="h-4 w-4" />
                 </Button>
@@ -83,7 +84,7 @@ export function Navbar({ session }: { session: Session | null }) {
                     className="flex items-center justify-between"
                   >
                     English
-                    {t("common.locale") === "en" && (
+                    {tCommon("locale") === "en" && (
                       <Check className="h-4 w-4" />
                     )}
                   </Link>
@@ -95,7 +96,7 @@ export function Navbar({ session }: { session: Session | null }) {
                     className="flex items-center justify-between"
                   >
                     Français
-                    {t("common.locale") === "fr" && (
+                    {tCommon("locale") === "fr" && (
                       <Check className="h-4 w-4" />
                     )}
                   </Link>
@@ -133,23 +134,23 @@ export function Navbar({ session }: { session: Session | null }) {
                   <DropdownMenuGroup>
                     <DropdownMenuItem onClick={() => router.push("/dashboard")}>
                       <LayoutDashboard className="mr-2 h-4 w-4" />
-                      {t("navbar.dashboard")}
+                      {tNavbar("dashboard")}
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => router.push("/account")}>
                       <User className="mr-2 h-4 w-4" />
-                      {t("navbar.account")}
+                      {tNavbar("account")}
                     </DropdownMenuItem>
                     {user.role === "admin" && (
                       <DropdownMenuItem onClick={() => router.push("/admin")}>
                         <Shield className="mr-2 h-4 w-4" />
-                        {t("navbar.admin")}
+                        {tNavbar("admin")}
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleSignOut}>
                     <LogOut className="mr-2 h-4 w-4" />
-                    {t("common.signOut")}
+                    {tCommon("signOut")}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -157,11 +158,11 @@ export function Navbar({ session }: { session: Session | null }) {
               <div className="flex items-center gap-2">
                 <Link href="/sign-in">
                   <Button variant="ghost" size="sm">
-                    {t("common.signIn")}
+                    {tCommon("signIn")}
                   </Button>
                 </Link>
                 <Link href="/sign-up">
-                  <Button size="sm">{t("common.signUp")}</Button>
+                  <Button size="sm">{tCommon("signUp")}</Button>
                 </Link>
               </div>
             )}

--- a/components/sidebar/nav-user.tsx
+++ b/components/sidebar/nav-user.tsx
@@ -40,7 +40,7 @@ export function NavUser({
   }
   billingPath: string
 }) {
-  const t = useTranslations()
+  const t = useTranslations("navUser")
   const router = useRouter()
   const { isMobile } = useSidebar()
 
@@ -111,28 +111,28 @@ export function NavUser({
             <DropdownMenuGroup>
               <DropdownMenuItem>
                 <Sparkles />
-                {t("navUser.upgradeToPro")}
+                {t("upgradeToPro")}
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
               <DropdownMenuItem onClick={() => router.push("/account")}>
                 <BadgeCheck />
-                {t("navUser.account")}
+                {t("account")}
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => router.push(billingPath)}>
                 <CreditCard />
-                {t("navUser.billing")}
+                {t("billing")}
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <Bell />
-                {t("navUser.notifications")}
+                {t("notifications")}
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleSignOut}>
               <LogOut />
-              {t("navUser.logOut")}
+              {t("logOut")}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/global.ts
+++ b/global.ts
@@ -5,5 +5,6 @@ declare module "next-intl" {
   interface AppConfig {
     Locale: (typeof routing.locales)[number]
     Messages: typeof messages
+    Formats: Record<string, never>
   }
 }

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -12,7 +12,8 @@ export const authClient = createAuthClient({
     adminClient(),
     twoFactorClient({
       onTwoFactorRedirect() {
-        window.location.href = "/2fa"
+        const locale = window.location.pathname.split("/")[1] || "en"
+        window.location.href = `/${locale}/2fa`
       },
     }),
     passkeyClient(),

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -10,6 +10,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
   return {
     locale,
+    timeZone: "UTC",
     messages: (await import(`../messages/${locale}.json`)).default,
   }
 })

--- a/lib/routing.ts
+++ b/lib/routing.ts
@@ -3,4 +3,5 @@ import { defineRouting } from "next-intl/routing"
 export const routing = defineRouting({
   locales: ["en", "fr"] as const,
   defaultLocale: "en",
+  localePrefix: "always",
 })

--- a/messages/en.json
+++ b/messages/en.json
@@ -25,7 +25,9 @@
     "pageNotFound": "Page not found",
     "changeLanguage": "Change language",
     "locale": "en",
-    "defaultRole": "User"
+    "defaultRole": "User",
+    "error": "Something went wrong",
+    "tryAgain": "Try again"
   },
   "navbar": {
     "dashboard": "Dashboard",
@@ -245,6 +247,20 @@
     "adminPanel": "Admin Panel",
     "operations": "Operations",
     "management": "Management"
+  },
+  "routeLabels": {
+    "dashboard": "Dashboard",
+    "account": "Account",
+    "admin": "Admin",
+    "users": "Users",
+    "billing": "Billing",
+    "analytics": "Analytics",
+    "system": "System Health",
+    "support": "Support",
+    "audit": "Audit Log",
+    "features": "Feature Flags",
+    "settings": "Settings",
+    "help": "Help"
   },
   "sidebar": {
     "dashboard": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -25,7 +25,9 @@
     "pageNotFound": "Page non trouvée",
     "changeLanguage": "Changer la langue",
     "locale": "fr",
-    "defaultRole": "Utilisateur"
+    "defaultRole": "Utilisateur",
+    "error": "Une erreur est survenue",
+    "tryAgain": "Réessayer"
   },
   "navbar": {
     "dashboard": "Tableau de bord",
@@ -245,6 +247,20 @@
     "adminPanel": "Panneau d'administration",
     "operations": "Opérations",
     "management": "Gestion"
+  },
+  "routeLabels": {
+    "dashboard": "Tableau de bord",
+    "account": "Compte",
+    "admin": "Admin",
+    "users": "Utilisateurs",
+    "billing": "Facturation",
+    "analytics": "Analytique",
+    "system": "État du système",
+    "support": "Support",
+    "audit": "Journal d'audit",
+    "features": "Fonctionnalités",
+    "settings": "Paramètres",
+    "help": "Aide"
   },
   "sidebar": {
     "dashboard": "Tableau de bord",


### PR DESCRIPTION
## Summary
Comprehensive next-intl implementation audit and fixes based on official documentation review.

### Critical Fixes
- **Dynamic `lang` attribute**: Moved `<html>`/`<body>` from root layout into `[locale]/layout.tsx` so `lang={locale}` is set dynamically (was hardcoded `lang="en"`, hurting French users' accessibility/SEO)
- **Locale-losing redirects**: Fixed `window.location.href` in `lib/auth-client.ts` (2FA redirect) and `admin/users/page.tsx` (impersonation redirect) to extract and preserve locale from pathname
- **Admin page missing params**: Added `params` signature to `admin/page.tsx` and replaced hardcoded `locale: "en"` with actual locale

### Medium Fixes
- **Static rendering**: Added `setRequestLocale` to 4 auth pages (2fa, forgot-password, reset-password, verify-email) enabling static generation
- **Error boundaries**: Created `app/[locale]/error.tsx` (locale-aware error boundary) and `app/not-found.tsx` (root 404 for non-localized requests)
- **Configuration**: Added `timeZone: "UTC"` to `lib/i18n.ts`, explicit `localePrefix: "always"` to `lib/routing.ts`
- **Namespace refactoring**: Refactored all 21 files using `useTranslations()`/`getTranslations()` to use explicit namespaces (zero bare calls remaining)
- **Translated route labels**: Admin and dashboard layout `routeLabels` now use `getTranslations("routeLabels")` with keys in `en.json`/`fr.json`

### Low Fixes
- **Type augmentation**: Added `Formats` interface to `global.ts` for future type-safe format names

### Deferred
- Admin page component text (~100+ strings) — tracked in [#72](https://github.com/Sabir222/saas/issues/72)

## Verification
- Build: passes | Lint: 0 errors | Types: passes `tsc --noEmit` | Knip: no issues | Tests: all pass