### PR TITLE
refactor: extract Zod error parsing into parseFormErrors utility

### DIFF
--- a/app/[locale]/(auth)/forgot-password/forgot-password-form.tsx
+++ b/app/[locale]/(auth)/forgot-password/forgot-password-form.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
 import { useForgotPasswordSchema } from "@/lib/schemas"
+import { parseFormErrors } from "@/lib/parse-form-errors"
 
 export function ForgotPasswordForm() {
   const t = useTranslations("auth.forgotPassword")
@@ -35,16 +36,10 @@ export function ForgotPasswordForm() {
     setError("")
     setEmailError("")
 
-    const result = forgotPasswordSchema.safeParse({ email })
+    const parsed = parseFormErrors(forgotPasswordSchema, { email })
 
-    if (!result.success) {
-      result.error.issues.forEach(
-        (err: { path: (string | number | symbol)[]; message: string }) => {
-          if (err.path[0]) {
-            setEmailError(err.message)
-          }
-        }
-      )
+    if (!parsed.success) {
+      setEmailError(parsed.errors.email ?? "")
       setIsLoading(false)
       return
     }

--- a/app/[locale]/(auth)/reset-password/reset-password-form.tsx
+++ b/app/[locale]/(auth)/reset-password/reset-password-form.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
 import { useResetPasswordSchema } from "@/lib/schemas"
+import { parseFormErrors } from "@/lib/parse-form-errors"
 
 export function ResetPasswordForm() {
   const t = useTranslations("auth.resetPassword")
@@ -38,18 +39,13 @@ export function ResetPasswordForm() {
     setIsLoading(true)
     setErrors({})
 
-    const result = resetPasswordSchema.safeParse({ password, confirmPassword })
+    const parsed = parseFormErrors(resetPasswordSchema, {
+      password,
+      confirmPassword,
+    })
 
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {}
-      result.error.issues.forEach(
-        (err: { path: (string | number | symbol)[]; message: string }) => {
-          if (err.path[0]) {
-            fieldErrors[err.path[0] as string] = err.message
-          }
-        }
-      )
-      setErrors(fieldErrors)
+    if (!parsed.success) {
+      setErrors(parsed.errors)
       setIsLoading(false)
       return
     }

--- a/app/[locale]/(auth)/sign-in/sign-in-form.tsx
+++ b/app/[locale]/(auth)/sign-in/sign-in-form.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
 import { useSignInSchema } from "@/lib/schemas"
+import { parseFormErrors } from "@/lib/parse-form-errors"
 
 export function SignInForm() {
   const t = useTranslations("auth.signIn")
@@ -34,18 +35,10 @@ export function SignInForm() {
     setIsLoading(true)
     setErrors({})
 
-    const result = signInSchema.safeParse({ email, password })
+    const parsed = parseFormErrors(signInSchema, { email, password })
 
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {}
-      result.error.issues.forEach(
-        (err: { path: (string | number | symbol)[]; message: string }) => {
-          if (err.path[0]) {
-            fieldErrors[err.path[0] as string] = err.message
-          }
-        }
-      )
-      setErrors(fieldErrors)
+    if (!parsed.success) {
+      setErrors(parsed.errors)
       setIsLoading(false)
       return
     }

--- a/app/[locale]/(auth)/sign-up/sign-up-form.tsx
+++ b/app/[locale]/(auth)/sign-up/sign-up-form.tsx
@@ -18,6 +18,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth-client"
 import { useSignUpSchema } from "@/lib/schemas"
+import { parseFormErrors } from "@/lib/parse-form-errors"
 
 export function SignUpForm() {
   const t = useTranslations("auth.signUp")
@@ -36,23 +37,15 @@ export function SignUpForm() {
     setIsLoading(true)
     setErrors({})
 
-    const result = signUpSchema.safeParse({
+    const parsed = parseFormErrors(signUpSchema, {
       name,
       email,
       password,
       confirmPassword,
     })
 
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {}
-      result.error.issues.forEach(
-        (err: { path: (string | number | symbol)[]; message: string }) => {
-          if (err.path[0]) {
-            fieldErrors[err.path[0] as string] = err.message
-          }
-        }
-      )
-      setErrors(fieldErrors)
+    if (!parsed.success) {
+      setErrors(parsed.errors)
       setIsLoading(false)
       return
     }

--- a/app/[locale]/(dashboard)/account/password-change-form.tsx
+++ b/app/[locale]/(dashboard)/account/password-change-form.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react"
 
 import { authClient } from "@/lib/auth-client"
 import { useChangePasswordSchema } from "@/lib/schemas"
+import { parseFormErrors } from "@/lib/parse-form-errors"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -33,25 +34,17 @@ export function PasswordChangeForm() {
     setPasswordError("")
     setPasswordSuccess(false)
 
-    const result = changePasswordSchema.safeParse({
+    const parsed = parseFormErrors(changePasswordSchema, {
       currentPassword,
       newPassword,
       confirmPassword,
     })
 
-    if (!result.success) {
-      const fieldErrors: Record<string, string> = {}
-      result.error.issues.forEach(
-        (err: { path: (string | number | symbol)[]; message: string }) => {
-          if (err.path[0]) {
-            fieldErrors[err.path[0] as string] = err.message
-          }
-        }
-      )
+    if (!parsed.success) {
       setPasswordError(
-        fieldErrors.confirmPassword ||
-          fieldErrors.newPassword ||
-          fieldErrors.currentPassword ||
+        parsed.errors.confirmPassword ||
+          parsed.errors.newPassword ||
+          parsed.errors.currentPassword ||
           t("validationFailed")
       )
       return

--- a/lib/parse-form-errors.ts
+++ b/lib/parse-form-errors.ts
@@ -1,0 +1,19 @@
+import type { ZodSchema } from "zod"
+
+export function parseFormErrors<T>(
+  schema: ZodSchema<T>,
+  data: unknown
+):
+  | { success: true; data: T }
+  | { success: false; errors: Record<string, string> } {
+  const result = schema.safeParse(data)
+  if (result.success) return { success: true, data: result.data }
+
+  const errors: Record<string, string> = {}
+  for (const issue of result.error.issues) {
+    if (issue.path[0]) {
+      errors[issue.path[0] as string] = issue.message
+    }
+  }
+  return { success: false, errors }
+}


### PR DESCRIPTION
## Summary

Extracts the duplicated Zod `safeParse` + error extraction logic into a pure utility function `parseFormErrors(schema, data)`.

### New file

`lib/parse-form-errors.ts` — 15-line pure function:
```ts
parseFormErrors(schema, data) → { success: true, data: T } | { success: false, errors: Record<string, string> }
```

### Updated forms (5 files)

Each form replaced the 10-15 line `safeParse` + `forEach` error extraction block with a single `parseFormErrors()` call:

- `sign-in/sign-in-form.tsx`
- `sign-up/sign-up-form.tsx`
- `forgot-password/forgot-password-form.tsx`
- `reset-password/reset-password-form.tsx`
- `dashboard/account/password-change-form.tsx`

### Verification

- Build: passes
- Lint: 0 errors

### Related

Closes #76