### PR TITLE
fix(auth): add TOTP verification step for 2FA enable flow (#85)

### DIFF
--- a/app/[locale]/(dashboard)/account/two-factor-manager.tsx
+++ b/app/[locale]/(dashboard)/account/two-factor-manager.tsx
@@ -44,6 +44,10 @@ export function TwoFactorManager() {
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [savedRecoveryCodes, setSavedRecoveryCodes] = useState(false)
   const [copiedBackupCodes, setCopiedBackupCodes] = useState(false)
+  const [verificationCode, setVerificationCode] = useState("")
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [verificationError, setVerificationError] = useState("")
+  const [isVerified, setIsVerified] = useState(false)
 
   const handleToggle2FA = () => {
     setTwoFactorError("")
@@ -72,6 +76,9 @@ export function TwoFactorManager() {
         setBackupCodes(data?.backupCodes ?? [])
         setSavedRecoveryCodes(false)
         setCopiedBackupCodes(false)
+        setVerificationCode("")
+        setVerificationError("")
+        setIsVerified(false)
         setShowTwoFactorSetup(true)
       } else {
         setTwoFactorError(tAccount("failedToEnable2FA"))
@@ -94,8 +101,25 @@ export function TwoFactorManager() {
     }
   }
 
+  const handleVerifyTOTP = async () => {
+    setVerificationError("")
+    setIsVerifying(true)
+
+    const { error } = await authClient.twoFactor.verifyTotp({
+      code: verificationCode,
+    })
+
+    if (!error) {
+      setIsVerified(true)
+    } else {
+      setVerificationError(tAccount("twoFactorSetup.invalidCode"))
+    }
+
+    setIsVerifying(false)
+  }
+
   const handleCloseTwoFactorSetup = () => {
-    if (!savedRecoveryCodes) return
+    if (!savedRecoveryCodes || !isVerified) return
     setShowTwoFactorSetup(false)
     setTwoFactorEnabled(true)
   }
@@ -215,6 +239,42 @@ export function TwoFactorManager() {
               </p>
             </div>
 
+            <div className="space-y-2 rounded-md border p-4">
+              <p className="text-sm font-medium">
+                {tAccount("twoFactorSetup.verifyCodeHint")}
+              </p>
+              {verificationError && (
+                <p className="text-sm text-destructive">{verificationError}</p>
+              )}
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={6}
+                  value={verificationCode}
+                  onChange={(e) =>
+                    setVerificationCode(e.target.value.replace(/\D/g, ""))
+                  }
+                  placeholder="000000"
+                  disabled={isVerified}
+                  className="text-center font-mono tracking-widest"
+                />
+                <Button
+                  onClick={handleVerifyTOTP}
+                  disabled={
+                    isVerifying || verificationCode.length !== 6 || isVerified
+                  }
+                >
+                  {isVerifying && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  {isVerified
+                    ? tAccount("twoFactorSetup.verified")
+                    : tAccount("twoFactorSetup.verify")}
+                </Button>
+              </div>
+            </div>
+
             <div className="rounded-md border p-4">
               <div className="mb-3 flex items-center justify-between">
                 <p className="font-medium">
@@ -271,7 +331,7 @@ export function TwoFactorManager() {
             </p>
             <Button
               onClick={handleCloseTwoFactorSetup}
-              disabled={!savedRecoveryCodes}
+              disabled={!savedRecoveryCodes || !isVerified}
             >
               {tAccount("twoFactorSetup.continueToAccount")}
             </Button>

--- a/messages/en.json
+++ b/messages/en.json
@@ -229,7 +229,11 @@
         "noBackupCodes": "No backup codes returned.",
         "savedCodes": "I saved my backup codes in a safe place.",
         "regenerateHint": "You can regenerate backup codes later from account settings.",
-        "continueToAccount": "Continue to account"
+        "continueToAccount": "Continue to account",
+        "verifyCodeHint": "Enter the 6-digit code from your authenticator app to verify setup.",
+        "verify": "Verify",
+        "invalidCode": "Invalid code. Please check your authenticator app and try again.",
+        "verified": "Verified"
       }
     }
   },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -229,7 +229,11 @@
         "noBackupCodes": "Aucun code de secours retourné.",
         "savedCodes": "J'ai sauvegardé mes codes de secours en lieu sûr.",
         "regenerateHint": "Vous pourrez régénérer les codes de secours plus tard dans les paramètres du compte.",
-        "continueToAccount": "Continuer vers le compte"
+        "continueToAccount": "Continuer vers le compte",
+        "verifyCodeHint": "Entrez le code à 6 chiffres de votre application d'authentification pour vérifier la configuration.",
+        "verify": "Vérifier",
+        "invalidCode": "Code invalide. Vérifiez votre application d'authentification et réessayez.",
+        "verified": "Vérifié"
       }
     }
   },


### PR DESCRIPTION
Closes #85

## Problem
When a user enables 2FA, scans the QR code, and clicks "Continue to account", the UI shows 2FA as enabled. After refreshing the page, 2FA shows as **disabled** again.

## Root Cause
Better Auth's `twoFactor` plugin has a two-step enable flow:
1. `enable()` — creates the TOTP secret + backup codes, but does NOT set `twoFactorEnabled = true`
2. `verifyTotp()` — user must enter a valid TOTP code; only then does `twoFactorEnabled` flip to `true`

The UI was missing step 2 entirely.

## Fix
Added a TOTP verification step in the 2FA setup dialog:
- 6-digit code input field after the QR code
- "Verify" button calls `authClient.twoFactor.verifyTotp({ code })`
- "Continue to account" button requires both verification AND saved backup codes
- Added translation keys for EN and FR